### PR TITLE
Fix for #108 and #111.  Reverting back to using Clone instead of Storable::dclone.

### DIFF
--- a/lib/Dancer/App.pm
+++ b/lib/Dancer/App.pm
@@ -43,7 +43,10 @@ sub routes {
 sub reload_apps {
     my ($class) = @_;
 
-    if (Dancer::ModuleLoader->load('Module::Refresh')) {
+    my @missing_modules = grep { not Dancer::ModuleLoader->load($_) }
+        qw(Module::Refresh Clone);
+
+    if (not @missing_modules) {
 
         # saving apps & purging app registries
         my $orig_apps = {};
@@ -63,8 +66,8 @@ sub reload_apps {
 
     }
     else {
-        warn "Module::Refresh is not installed, "
-          . "install this module or unset 'auto_reload' in your config file";
+        warn "Modules required for auto_reload are missing. Install modules"
+            . " [@missing_modules] or unset 'auto_reload' in your config file.";
     }
 }
 

--- a/lib/Dancer/Config.pm
+++ b/lib/Dancer/Config.pm
@@ -267,7 +267,7 @@ $public/$error_code.html if it exists.
 
 =head2 auto_reload (boolean)
 
-Requires L<Module::Refresh>.
+Requires L<Module::Refresh> and L<Clone>.
 
 If set to true, Dancer will reload the route handlers whenever the file where
 they are defined is changed. This is very useful in development environment but

--- a/lib/Dancer/Object.pm
+++ b/lib/Dancer/Object.pm
@@ -5,13 +5,6 @@ package Dancer::Object;
 
 use strict;
 use warnings;
-use Storable 'dclone';
-{ # We have to set $Deparse and $Eval to be able to clone objects that contain
-  # coderefs http://p3rl.org/Storable#CODE_REFERENCES
-    no warnings 'once';
-    $Storable::Deparse = 1;
-    $Storable::Eval = 1;
-}
 
 # constructor
 sub new {
@@ -24,7 +17,9 @@ sub new {
 
 sub clone {
     my ($self) = @_;
-    return dclone($self);
+    die "The 'Clone' module is needed"
+        unless Dancer::ModuleLoader->load('Clone');
+    return Clone::clone($self);
 }
 
 # initializer

--- a/script/dancer
+++ b/script/dancer
@@ -39,7 +39,7 @@ my $DO_OVERWRITE_ALL = 0;
 my $DANCER_APP_DIR   = get_application_path($path, $name);
 my $DANCER_SCRIPT    = get_script_path($name);
 my ($LIB_FILE, $LIB_PATH) = get_lib_path($name);
-my $AUTO_RELOAD = eval "require Module::Refresh" ? 1 : 0;
+my $AUTO_RELOAD = eval "require Module::Refresh and require Clone" ? 1 : 0;
 
 require Dancer;
 my $DANCER_VERSION   = $Dancer::VERSION;


### PR DESCRIPTION
Clone is now required (in addition to Module::Refresh) if people want to use the auto_reload feature.  Clone is not a hard dependency of Dancer.  auto_load will be set to 1 in the dev. config for a scaffolded app only if both Clone and Module::Refresh are already installed.
