### PR TITLE
default tmpl extension

### DIFF
--- a/lib/Dancer/Template/Abstract.pm
+++ b/lib/Dancer/Template/Abstract.pm
@@ -10,9 +10,13 @@ use base 'Dancer::Engine';
 # return: a string of $template's content processed with $tokens
 sub render { die "render not implemented" }
 
+sub default_tmpl_ext { "tt" };
+
 sub view {
     my ($self, $view) = @_;
-    $view .= ".tt" if $view !~ /\.tt$/;
+
+    my $def_tmpl_ext = $self->default_tmpl_ext();
+    $view .= ".$def_tmpl_ext" if $view !~ /\.${def_tmpl_ext}$/;
 
     my $app = Dancer::App->current;
     return path($app->setting('views'), $view);
@@ -22,7 +26,8 @@ sub layout {
     my ($self, $layout, $tokens, $content) = @_;
 
     my $app = Dancer::App->current;
-    $layout .= '.tt' if $layout !~ /\.tt/;
+    my $def_tmpl_ext = $self->default_tmpl_ext();
+    $layout .= ".$def_tmpl_ext" if $layout !~ /\.${def_tmpl_ext}$/;
     $layout = path($app->setting('views'), 'layouts', $layout);
 
     my $full_content =


### PR DESCRIPTION
Can you please take a look at this patch, I don't thing there is a need for templates to both override view or layout in order to change the default ".tt", so I added a function that will return a default template extension.

Now in Dancer::Template::Mason you just add:
default_tmpl_extension { "mason" }  on it works

also all test pass

All tests successful.
Files=130, Tests=1133, 27 wallclock secs ( 0.55 usr  0.21 sys + 19.80 cusr  2.50 csys = 23.06 CPU)
Result: PASS
