### PR TITLE
Updating scaffolded app to work out of the box when run via a webserver and not mounted under root (/).

### DIFF
--- a/script/dancer
+++ b/script/dancer
@@ -452,9 +452,9 @@ WriteMakefile(
 <html>
 <head>
 <title>'.$appname.'</title>
-<link rel="stylesheet" href="/css/style.css" />
+<link rel="stylesheet" href="<% uri_base %>/css/style.css" />
 <meta http-equiv="Content-type" content="text/html; charset=UTF-8" />
-<script type="text/javascript" src="/javascripts/jquery.js"></script> 
+<script type="text/javascript" src="<% uri_base %>/javascripts/jquery.js"></script> 
 </head>
 <body>
 <% content %>
@@ -505,6 +505,14 @@ dance;
 use Dancer ':syntax';
 
 our \$VERSION = '0.1';
+
+# This will help templates construct paths to static files if your app is served
+# via a webserver and not mounted under root (/). This is not necessary when
+# running standalone. Look in views/layouts/main.tt to see how uri_base is used.
+before_template sub {
+    my \$template_vars = shift;
+    \$template_vars->{uri_base} = request->base;
+};
 
 get '/' => sub {
     template 'index';


### PR DESCRIPTION
Not sure if the added complexity is worth the benefit, but this will make the scaffolded app more robust.  Previously, running the scaffolded app via a webserver, the css and javascript does not get loaded properly, unless this is the only app you are serving and so you have it mounted under root (/).

With this change, the scaffolded app will work correctly if someone links to it from cgi-bin:

```
cd /usr/lib/cgi-bin
ln -s /path_to_app/public/dispatch.cgi myapp.cgi
```

It will also just work if someone wants to use a rewrite rule:

```
url.rewrite = ( "^/foo(.*)" => "/cgi-bin/myapp.cgi$1" )
```

I basically implemented the suggestion Franck added to the Dancer::Cookbook#Layouts section where he uses a before_template filter.

This pull request lists 2 commits.  Only the second (later) commit pertains to this.  I couldn't figure out how to do a pull request with just the second commit.  I think maybe it is because both of the commits are on the same file.  The first commit is for issue #116.
