### PR TITLE
Check that a plugin doesn't try to use keywords reserved by a previous plugin

### DIFF
--- a/lib/Dancer/Plugin.pm
+++ b/lib/Dancer/Plugin.pm
@@ -45,6 +45,12 @@ sub register($&) {
     if (grep { $_ eq $keyword } @_reserved_keywords) {
         die "You can't use $keyword, this is a reserved keyword";
     }
+    while (my ($plugin, $keywords) = each %$_keywords) {
+        if (grep { $_->[0] eq $keyword } @$keywords) {
+            die "You can't use $keyword, this is a keyword reserved by $plugin";
+        }
+    }
+
     $_keywords->{$plugin_name} ||= [];
     push @{$_keywords->{$plugin_name}}, [$keyword => $code];
 }


### PR DESCRIPTION
I didn't know how to add test for this, as I am very new to Dancer, but I checked that it didn't break the existing test suite.
