### PR TITLE
use carp, croak and confess from Carp, instead of die and warn 

### DIFF
--- a/lib/Dancer.pm
+++ b/lib/Dancer.pm
@@ -2,7 +2,7 @@ package Dancer;
 
 use strict;
 use warnings;
-use Carp 'confess';
+use Carp;
 use Cwd 'abs_path', 'realpath';
 use vars qw($VERSION $AUTHORITY @EXPORT);
 
@@ -133,7 +133,7 @@ sub prefix { Dancer::App->current->set_prefix(@_) }
 sub del     { Dancer::App->current->registry->universal_add('delete',  @_) }
 sub options { Dancer::App->current->registry->universal_add('options', @_) }
 sub put     { Dancer::App->current->registry->universal_add('put',     @_) }
-sub r { warn "'r' is DEPRECATED use qr{} instead"; return {regexp => $_[0]} }
+sub r { carp "'r' is DEPRECATED use qr{} instead"; return {regexp => $_[0]} }
 sub redirect  { Dancer::Helpers::redirect(@_) }
 sub request   { Dancer::SharedData->request }
 sub send_file { Dancer::Helpers::send_file(@_) }
@@ -191,7 +191,7 @@ sub load_app {
     my ($package, $script) = caller;
     _init($script);
     my ($res, $error) = Dancer::ModuleLoader->load($app_name);
-    $res or die "unable to load application $app_name : $error";
+    $res or croak "unable to load application $app_name : $error";
 
     # restore the main application
     Dancer::App->set_running_app('main');
@@ -269,7 +269,7 @@ sub _init {
     setting logger => 'file';
 
     my ($res, $error) = Dancer::ModuleLoader->use_lib(path(setting('appdir'), 'lib'));
-    $res or die "unable to set libdir : $error";
+    $res or croak "unable to set libdir : $error";
 }
 
 1;

--- a/lib/Dancer/App.pm
+++ b/lib/Dancer/App.pm
@@ -2,6 +2,7 @@ package Dancer::App;
 
 use strict;
 use warnings;
+use Carp;
 use base 'Dancer::Object';
 
 use Dancer::Config;
@@ -29,7 +30,7 @@ sub set_running_app {
 
 sub set_prefix {
     my ($self, $prefix) = @_;
-    die "not a valid prefix: `$prefix', must start with a /"
+    croak "not a valid prefix: `$prefix', must start with a /"
       if defined($prefix) && $prefix !~ /^\//;
     Dancer::App->current->prefix($prefix);
     return 1;    # prefix may have been set to undef
@@ -66,7 +67,7 @@ sub reload_apps {
 
     }
     else {
-        warn "Modules required for auto_reload are missing. Install modules"
+        carp "Modules required for auto_reload are missing. Install modules"
             . " [@missing_modules] or unset 'auto_reload' in your config file.";
     }
 }
@@ -122,7 +123,7 @@ sub init {
     my ($self) = @_;
     $self->name('main') unless defined $self->name;
 
-    die "an app named '" . $self->name . "' already exists"
+    croak "an app named '" . $self->name . "' already exists"
       if exists $_apps->{$self->name};
 
     # default values for properties

--- a/lib/Dancer/Development.pod
+++ b/lib/Dancer/Development.pod
@@ -158,11 +158,11 @@ perform a dynamic loading. Dancer has a class dedicated to that job:
 L<Dancer::ModuleLoader>. Here is an example of how to use it:
 
     package Dancer::Some::Thing;
-    
+    use Carp;
+
     sub init {
-        unless (Dancer::ModuleLoader->load('Some::Deps')) {
-            die "the feature provided by Dancer::Some::Thing needs Some::Deps";
-        }
+        Dancer::ModuleLoader->load('Some::Deps')
+            or croak "the feature provided by Dancer::Some::Thing needs Some::Deps";
     }
 
 That way, an optional feature doesn't block Dancer from being installed as the

--- a/lib/Dancer/Engine.pm
+++ b/lib/Dancer/Engine.pm
@@ -6,6 +6,7 @@ package Dancer::Engine;
 
 use strict;
 use warnings;
+use Carp;
 use Dancer::ModuleLoader;
 use base 'Dancer::Object';
 
@@ -29,7 +30,7 @@ sub config {
 sub build {
     my ($class, $type, $name, $config) = @_;
 
-    die "cannot build engine without type and name "
+    croak "cannot build engine without type and name "
       unless $name and $type;
 
     my $class_name = ucfirst($type);
@@ -43,7 +44,7 @@ sub build {
     my $engine_class =
       Dancer::ModuleLoader->class_from_setting($namespace => $name);
 
-    die "unknown $type engine '$name', "
+    croak "unknown $type engine '$name', "
       . "perhaps you need to install $engine_class?"
       unless Dancer::ModuleLoader->load($engine_class);
 

--- a/lib/Dancer/Error.pm
+++ b/lib/Dancer/Error.pm
@@ -2,6 +2,7 @@ package Dancer::Error;
 
 use strict;
 use warnings;
+use Carp;
 
 use Dancer::Response;
 use Dancer::Renderer;
@@ -125,7 +126,7 @@ sub dumper {
 sub _censor {
     my $hash = shift;
     if (!$hash || ref $hash ne 'HASH') {
-        warn "_censor given incorrect input: $hash";
+        carp "_censor given incorrect input: $hash";
         return;
     }
 

--- a/lib/Dancer/Handler/PSGI.pm
+++ b/lib/Dancer/Handler/PSGI.pm
@@ -2,6 +2,7 @@ package Dancer::Handler::PSGI;
 
 use strict;
 use warnings;
+use Carp;
 use base 'Dancer::Handler';
 
 use Dancer::GetOpt;
@@ -14,7 +15,7 @@ use Dancer::Logger;
 sub new {
     my $class = shift;
 
-    die "Plack::Request is needed by the PSGI handler"
+    croak "Plack::Request is needed by the PSGI handler"
       unless Dancer::ModuleLoader->load('Plack::Request');
 
     my $self = {};
@@ -34,7 +35,7 @@ sub dance {
 
     if (Dancer::Config::setting('plack_middlewares')) {
         my $middlewares = Dancer::Config::setting('plack_middlewares');
-        die "Plack::Builder is needed for middlewares support"
+        croak "Plack::Builder is needed for middlewares support"
           unless Dancer::ModuleLoader->load('Plack::Builder');
 
         my $builder = Plack::Builder->new();

--- a/lib/Dancer/Headers.pm
+++ b/lib/Dancer/Headers.pm
@@ -1,6 +1,7 @@
 package Dancer::Headers;
 use strict;
 use warnings;
+use Carp;
 use base 'Dancer::Object';
 
 sub init {
@@ -31,7 +32,7 @@ sub init {
         $self->{_headers_type} = 'http_headers';
     }
     else {
-        die "unsupported headers: $headers";
+        croak "unsupported headers: $headers";
     }
 
     return $self;

--- a/lib/Dancer/Logger/Abstract.pm
+++ b/lib/Dancer/Logger/Abstract.pm
@@ -2,6 +2,7 @@ package Dancer::Logger::Abstract;
 
 use strict;
 use warnings;
+use Carp;
 use base 'Dancer::Engine';
 
 use Dancer::SharedData;
@@ -12,7 +13,7 @@ use Dancer::Config 'setting';
 # It receives the following arguments:
 # $msg_level, $msg_content, it gets called only if the configuration allows
 # a message of the given level to be logged.
-sub _log { die "_log not implemented" }
+sub _log { confess "_log not implemented" }
 
 sub _should {
     my ($self, $msg_level) = @_;

--- a/lib/Dancer/Logger/File.pm
+++ b/lib/Dancer/Logger/File.pm
@@ -1,6 +1,7 @@
 package Dancer::Logger::File;
 use strict;
 use warnings;
+use Carp;
 use base 'Dancer::Logger::Abstract';
 
 use File::Spec;
@@ -20,7 +21,7 @@ sub init {
 
     if (!-d $logdir) {
         if (not mkdir $logdir) {
-            warn "log directory $logdir doesn't exist, unable to create";
+            carp "log directory $logdir doesn't exist, unable to create";
             undef $logfile;
             return;
         }
@@ -31,7 +32,7 @@ sub init {
 
     my $fh;
     unless (open($fh, '>>', $logfile)) {
-        warn "Unable to open $logfile for writing, unable to log";
+        carp "Unable to open $logfile for writing, unable to log";
         undef $logfile;
     }
     close $fh;

--- a/lib/Dancer/Object.pm
+++ b/lib/Dancer/Object.pm
@@ -5,6 +5,7 @@ package Dancer::Object;
 
 use strict;
 use warnings;
+use Carp;
 
 # constructor
 sub new {
@@ -17,7 +18,7 @@ sub new {
 
 sub clone {
     my ($self) = @_;
-    die "The 'Clone' module is needed"
+    croak "The 'Clone' module is needed"
         unless Dancer::ModuleLoader->load('Clone');
     return Clone::clone($self);
 }

--- a/lib/Dancer/Plugin.pm
+++ b/lib/Dancer/Plugin.pm
@@ -1,6 +1,7 @@
 package Dancer::Plugin;
 use strict;
 use warnings;
+use Carp;
 
 use base 'Exporter';
 use Dancer::Config 'setting';
@@ -43,11 +44,11 @@ sub register($&) {
     my $plugin_name = caller();
 
     if (grep { $_ eq $keyword } @_reserved_keywords) {
-        die "You can't use $keyword, this is a reserved keyword";
+        croak "You can't use $keyword, this is a reserved keyword";
     }
     while (my ($plugin, $keywords) = each %$_keywords) {
         if (grep { $_->[0] eq $keyword } @$keywords) {
-            die "You can't use $keyword, this is a keyword reserved by $plugin";
+            croak "You can't use $keyword, this is a keyword reserved by $plugin";
         }
     }
 
@@ -70,7 +71,7 @@ sub register_plugin {
 
 sub load_plugin {
     my ($plugin) = @_;
-    die "load_plugin is DEPRECATED, you must use 'use' instead";
+    croak "load_plugin is DEPRECATED, you must use 'use' instead";
 }
 
 sub set_plugin_symbols {

--- a/lib/Dancer/Plugin/WebSocket.pm
+++ b/lib/Dancer/Plugin/WebSocket.pm
@@ -2,6 +2,7 @@ package Dancer::Plugin::WebSocket;
 
 use strict;
 use warnings;
+use Carp;
 
 use Dancer ':syntax';
 use Dancer::Plugin;
@@ -9,7 +10,7 @@ use Dancer::Plugin;
 register websocket => \&websocket;
 
 BEGIN {
-    die "Plack is required for WebSocket support"
+    croak "Plack is required for WebSocket support"
       unless Dancer::ModuleLoader->load('Plack::Builder');
 }
 

--- a/lib/Dancer/Renderer.pm
+++ b/lib/Dancer/Renderer.pm
@@ -2,6 +2,7 @@ package Dancer::Renderer;
 
 use strict;
 use warnings;
+use Carp;
 
 use Dancer::Route;
 use Dancer::HTTP;
@@ -109,7 +110,7 @@ sub get_action_response {
     {
         $limit++;
         if ($limit > $MAX_RECURSIVE_LOOP) {
-            die "infinite loop detected, "
+            croak "infinite loop detected, "
               . "check your route/filters for "
               . $method . ' '
               . $path;

--- a/lib/Dancer/Request.pm
+++ b/lib/Dancer/Request.pm
@@ -2,6 +2,8 @@ package Dancer::Request;
 
 use strict;
 use warnings;
+use Carp;
+
 use Dancer::Object;
 use Dancer::Headers;
 use Dancer::Request::Upload;
@@ -146,7 +148,7 @@ sub params {
         return $self->{_route_params};
     }
     else {
-        die "Unknown source params \"$source\".";
+        croak "Unknown source params \"$source\".";
     }
 }
 
@@ -269,7 +271,7 @@ sub _build_path {
         $path ||= $self->_url_decode($self->{request_uri});
     }
 
-    die "Cannot resolve path" if not $path;
+    croak "Cannot resolve path" if not $path;
     $self->{path} = $path;
 }
 
@@ -381,7 +383,7 @@ sub _read {
         return $buffer;
     }
     else {
-        die "Unknown error reading input: $!";
+        croak "Unknown error reading input: $!";
     }
 }
 

--- a/lib/Dancer/Request/Upload.pm
+++ b/lib/Dancer/Request/Upload.pm
@@ -1,6 +1,7 @@
 package Dancer::Request::Upload;
 
 use File::Spec;
+use Carp;
 
 use strict;
 use warnings;
@@ -16,7 +17,7 @@ sub file_handle {
     my ($self) = @_;
     return $self->{_fh} if defined $self->{_fh};
     open my $fh, '<', $self->tempname
-      or die "Can't open `" . $self->tempname . "' for reading: $!";
+      or croak "Can't open `" . $self->tempname . "' for reading: $!";
     $self->{_fh} = $fh;
 }
 

--- a/lib/Dancer/Route.pm
+++ b/lib/Dancer/Route.pm
@@ -2,6 +2,7 @@ package Dancer::Route;
 
 use strict;
 use warnings;
+use Carp;
 use base 'Dancer::Object';
 
 use Dancer::App;
@@ -34,7 +35,7 @@ sub init {
     $self->{'_compiled_regexp'} = undef;
 
     if (!$self->pattern) {
-        die "cannot create Dancer::Route without a pattern";
+        croak "cannot create Dancer::Route without a pattern";
     }
 
     $self->check_options();
@@ -120,7 +121,7 @@ sub check_options {
     return 1 unless defined $self->options;
 
     for my $opt (keys %{$self->options}) {
-        die "Not a valid option for route matching: `$opt'"
+        croak "Not a valid option for route matching: `$opt'"
           if not(    (grep {/^$opt$/} @{$_supported_options[0]})
                   || (grep {/^$opt$/} keys(%_options_aliases)));
     }
@@ -151,7 +152,7 @@ sub run {
             return $next_route->run($request);
         }
         else {
-            die "Last matching route passed";
+            croak "Last matching route passed";
         }
     }
 

--- a/lib/Dancer/Route/Cache.pm
+++ b/lib/Dancer/Route/Cache.pm
@@ -2,6 +2,7 @@ package Dancer::Route::Cache;
 
 use strict;
 use warnings;
+use Carp;
 use vars '$VERSION';
 
 use Dancer::Object;
@@ -72,7 +73,7 @@ sub route_from_path {
     my ($self, $method, $path) = @_;
 
     $method && $path
-      or die "Missing method or path";
+      or croak "Missing method or path";
 
     return $self->{'cache'}{$method}{$path} || undef;
 }
@@ -81,7 +82,7 @@ sub store_path {
     my ($self, $method, $path, $route) = @_;
 
     $method && $path && $route
-      or die "Missing method, path or route";
+      or croak "Missing method, path or route";
 
     $self->{'cache'}{$method}{$path} = $route;
 

--- a/lib/Dancer/Route/Registry.pm
+++ b/lib/Dancer/Route/Registry.pm
@@ -1,6 +1,7 @@
 package Dancer::Route::Registry;
 use strict;
 use warnings;
+use Carp;
 
 use base 'Dancer::Object';
 use Dancer::Logger;
@@ -129,7 +130,7 @@ sub any_add {
         $pattern = shift @rest;
     }
 
-    die "Syntax error, methods should be provided as an ARRAY ref"
+    croak "Syntax error, methods should be provided as an ARRAY ref"
       if grep {/^$pattern$/} @methods;
 
     $self->universal_add($_, $pattern, @rest) for @methods;

--- a/lib/Dancer/Serializer/Abstract.pm
+++ b/lib/Dancer/Serializer/Abstract.pm
@@ -2,10 +2,11 @@ package Dancer::Serializer::Abstract;
 
 use strict;
 use warnings;
+use Carp;
 use base 'Dancer::Engine';
 
-sub serialize   { die 'must be implemented' }
-sub deserialize { die 'must be implemented' }
+sub serialize   { confess 'must be implemented' }
+sub deserialize { confess 'must be implemented' }
 
 # must be implemented to delcare if the serializer can be used or not
 # most of the time, just use :

--- a/lib/Dancer/Serializer/Dumper.pm
+++ b/lib/Dancer/Serializer/Dumper.pm
@@ -2,6 +2,7 @@ package Dancer::Serializer::Dumper;
 
 use strict;
 use warnings;
+use Carp;
 use base 'Dancer::Serializer::Abstract';
 use Data::Dumper;
 
@@ -31,7 +32,7 @@ sub serialize {
 sub deserialize {
     my ($self, $content) = @_;
     my $res = eval "my \$VAR1; $content";
-    die "unable to deserialize : $@" if $@;
+    croak "unable to deserialize : $@" if $@;
     return $res;
 }
 

--- a/lib/Dancer/Serializer/JSON.pm
+++ b/lib/Dancer/Serializer/JSON.pm
@@ -2,6 +2,7 @@ package Dancer::Serializer::JSON;
 
 use strict;
 use warnings;
+use Carp;
 use Dancer::ModuleLoader;
 use Dancer::Config 'setting';
 use base 'Dancer::Serializer::Abstract';
@@ -25,7 +26,7 @@ sub loaded { Dancer::ModuleLoader->load('JSON') }
 
 sub init {
     my ($self) = @_;
-    die 'JSON is needed and is not installed'
+    croak 'JSON is needed and is not installed'
       unless $self->loaded;
 }
 

--- a/lib/Dancer/Serializer/XML.pm
+++ b/lib/Dancer/Serializer/XML.pm
@@ -2,6 +2,7 @@ package Dancer::Serializer::XML;
 
 use strict;
 use warnings;
+use Carp;
 use Dancer::ModuleLoader;
 use base 'Dancer::Serializer::Abstract';
 
@@ -26,7 +27,7 @@ sub loaded { Dancer::ModuleLoader->load('XML::Simple') }
 
 sub init {
     my ($self) = @_;
-    die 'XML::Simple is needed and is not installed'
+    croak 'XML::Simple is needed and is not installed'
       unless $self->loaded;
     $_xs = XML::Simple->new();
 }

--- a/lib/Dancer/Serializer/YAML.pm
+++ b/lib/Dancer/Serializer/YAML.pm
@@ -2,6 +2,7 @@ package Dancer::Serializer::YAML;
 
 use strict;
 use warnings;
+use Carp;
 use Dancer::ModuleLoader;
 use base 'Dancer::Serializer::Abstract';
 
@@ -25,7 +26,7 @@ sub loaded { Dancer::ModuleLoader->load('YAML') }
 
 sub init {
     my ($self) = @_;
-    die 'YAML is needed and is not installed'
+    croak 'YAML is needed and is not installed'
       unless $self->loaded;
 }
 

--- a/lib/Dancer/Session/Abstract.pm
+++ b/lib/Dancer/Session/Abstract.pm
@@ -1,6 +1,7 @@
 package Dancer::Session::Abstract;
 use strict;
 use warnings;
+use Carp;
 
 use base 'Dancer::Engine';
 
@@ -20,25 +21,25 @@ __PACKAGE__->attributes('id');
 # receives a session id and should return a session object if found, or undef
 # otherwise.
 sub retrieve {
-    die "retrieve not implemented";
+    confess "retrieve not implemented";
 }
 
 # args: ($class)
 # create a new empty session, flush it and return it.
 sub create {
-    die "create not implemented";
+    confess "create not implemented";
 }
 
 # args: ($self)
 # write the (serialized) current session to the session storage
 sub flush {
-    die "flush not implemented";
+    confess "flush not implemented";
 }
 
 # args: ($self)
 # remove the session from the session storage
 sub destroy {
-    die "destroy not implemented";
+    confess "destroy not implemented";
 }
 
 

--- a/lib/Dancer/Session/YAML.pm
+++ b/lib/Dancer/Session/YAML.pm
@@ -2,6 +2,7 @@ package Dancer::Session::YAML;
 
 use strict;
 use warnings;
+use Carp;
 use base 'Dancer::Session::Abstract';
 
 use Dancer::ModuleLoader;
@@ -13,7 +14,7 @@ use Dancer::FileUtils 'path';
 sub init {
     my ($class) = @_;
 
-    die "YAML is needed and is not installed"
+    croak "YAML is needed and is not installed"
       unless Dancer::ModuleLoader->load('YAML');
 
     # default value for session_dir
@@ -24,7 +25,7 @@ sub init {
     my $session_dir = setting('session_dir');
     if (!-d $session_dir) {
         mkdir $session_dir
-          or die "session_dir $session_dir cannot be created";
+          or croak "session_dir $session_dir cannot be created";
     }
     Dancer::Logger->debug("session_dir : $session_dir");
 }
@@ -63,7 +64,7 @@ sub destroy {
 
 sub flush {
     my $self = shift;
-    open(my $sessionfh, '>', yaml_file($self->id)) or die $!;
+    open(my $sessionfh, '>', yaml_file($self->id)) or croak $!;
     print {$sessionfh} YAML::Dump($self);
     close $sessionfh;
     return $self;

--- a/lib/Dancer/Template/Abstract.pm
+++ b/lib/Dancer/Template/Abstract.pm
@@ -2,13 +2,14 @@ package Dancer::Template::Abstract;
 
 use strict;
 use warnings;
+use Carp;
 use Dancer::FileUtils 'path';
 use base 'Dancer::Engine';
 
 # Overloads this method to implement the rendering
 # args:   $self, $template, $tokens
 # return: a string of $template's content processed with $tokens
-sub render { die "render not implemented" }
+sub render { confess "render not implemented" }
 
 sub default_tmpl_ext { "tt" };
 

--- a/lib/Dancer/Template/Simple.pm
+++ b/lib/Dancer/Template/Simple.pm
@@ -1,6 +1,7 @@
 package Dancer::Template::Simple;
 use strict;
 use warnings;
+use Carp;
 
 use base 'Dancer::Template::Abstract';
 Dancer::Template::Simple->attributes('start_tag', 'stop_tag');
@@ -105,10 +106,10 @@ sub _read_content_from_template {
         $content = $$template;
     }
     else {
-        die "'$template' is not a regular file"
+        croak "'$template' is not a regular file"
           unless -f $template;
         $content = read_file_content($template);
-        die "unable to read content for file $template"
+        croak "unable to read content for file $template"
           if not defined $content;
     }
     return $content;

--- a/lib/Dancer/Template/TemplateToolkit.pm
+++ b/lib/Dancer/Template/TemplateToolkit.pm
@@ -2,6 +2,7 @@ package Dancer::Template::TemplateToolkit;
 
 use strict;
 use warnings;
+use Carp;
 use Dancer::Config 'setting';
 use Dancer::ModuleLoader;
 use Dancer::FileUtils 'path';
@@ -13,7 +14,7 @@ my $_engine;
 sub init {
     my ($self) = @_;
 
-    die "Template is needed by Dancer::Template::TemplateToolkit"
+    croak "Template is needed by Dancer::Template::TemplateToolkit"
       unless Dancer::ModuleLoader->load('Template');
 
     my $tt_config = {
@@ -41,11 +42,11 @@ sub init {
 
 sub render {
     my ($self, $template, $tokens) = @_;
-    die "'$template' is not a regular file"
+    croak "'$template' is not a regular file"
       if !ref($template) && (!-f $template);
 
     my $content = "";
-    $_engine->process($template, $tokens, \$content, binmode => ':utf8') or die $_engine->error;
+    $_engine->process($template, $tokens, \$content, binmode => ':utf8') or croak $_engine->error;
     return $content;
 }
 


### PR DESCRIPTION
The simple policy I've applied is : replace die by croak, warn by carp. However, in abstract classes (like Dancer/Template/Abstract), the methode which have to be overridden confess when not overridden, instead of dying. That way you get the full stack. I did that because these errors happen usually when you are implementing a plugin, and in this case the stacktrace is useful.

Is there a Dancer debug mode ? if yes, it would be useful to set $Carp::Verbose to tru in this mode, so that all croak and carp return the full stacktrace.

All the test currently pass, including the one that check warn messages or die messages.
