### PR TITLE
added a setting to control stak traces display 

### DIFF
--- a/lib/Dancer/Config.pm
+++ b/lib/Dancer/Config.pm
@@ -60,6 +60,10 @@ my $setters = {
             );
         }
     },
+    traces => sub {
+        my ($setting, $traces) = @_;
+        $Carp::Verbose = $traces ? 1 : 0;
+    },
 };
 
 # public accessor for get/set
@@ -142,6 +146,7 @@ sub load_default_settings {
     $SETTINGS->{apphandler}   ||= $ENV{DANCER_APPHANDLER}   || 'Standalone';
     $SETTINGS->{warnings}     ||= $ENV{DANCER_WARNINGS}     || 0;
     $SETTINGS->{auto_reload}  ||= $ENV{DANCER_AUTO_RELOAD}  || 0;
+    $SETTINGS->{traces}       ||= $ENV{DANCER_TRACES}       || 0;
     $SETTINGS->{environment} 
       ||= $ENV{DANCER_ENVIRONMENT}
       || $ENV{PLACK_ENV}
@@ -243,6 +248,11 @@ a matching template in the directory $appdir/views/layout.
 =head2 warnings (boolean)
 
 If set to true, tells Dancer to consider all warnings as blocking errors.
+
+=head2 traces (boolean)
+
+If set to true, Dancer will display full stack traces when a warning or a die
+occurs. (Internally sets Carp::Verbose). Default to false.
 
 =head2 log (enum)
 

--- a/t/01_config/06_stack_trace.t
+++ b/t/01_config/06_stack_trace.t
@@ -1,0 +1,51 @@
+use strict;
+use warnings;
+
+use Test::More tests => 16, import => ['!pass'];
+
+use Dancer ':syntax';
+use Dancer::Template::TemplateToolkit;
+
+# scoping for $Carp::Verbose localization
+
+{
+    # first of all, test without verbose Carp
+    local $Carp::Verbose = 0;
+    eval { Dancer::Template::TemplateToolkit->render('/not/a/valid/file'); };
+    my @error_lines = split(/\n/, $@);
+    is(scalar(@error_lines), 1, "test non verbose croak");
+    like($error_lines[0], qr!^'/not/a/valid/file' is not a regular file at!, "test non verbose croak");
+}
+
+{
+    # same with verbose Carp
+    local $Carp::Verbose = 1;
+    eval { Dancer::Template::TemplateToolkit->render('/not/a/valid/file'); };
+    my @error_lines = split(/\n/, $@);
+    is(scalar(@error_lines), 3, "test verbose croak");
+    like($error_lines[0], qr!^'/not/a/valid/file' is not a regular file at!, "test verbose croak");
+    like($error_lines[1], qr!^\s*Dancer::Template::TemplateToolkit::render\('Dancer::Template::TemplateToolkit', '/not/a/valid/file'\) called at!, "test verbose croak stack trace");
+    like($error_lines[2], qr!^\s*eval {...} called at t/01_config/06_stack_trace.t!, "test verbose croak stack trace");
+}
+
+{
+    # test that default Dancer traces setting is no verbose
+    is(setting('traces'), 0, "default 'traces' option set to 0");
+    is($Carp::Verbose, 0, "default Carp verbose is 0");
+    eval { Dancer::Template::TemplateToolkit->render('/not/a/valid/file'); };
+    my @error_lines = split(/\n/, $@);
+    is(scalar(@error_lines), 1, "test non verbose croak 2");
+    like($error_lines[0], qr!^'/not/a/valid/file' is not a regular file at!, "test non verbose croak 2");
+}
+
+{
+    # test setting traces to 1
+    ok(setting(traces => 1));
+    is($Carp::Verbose, 1, "new Carp verbose is 1");
+    eval { Dancer::Template::TemplateToolkit->render('/not/a/valid/file'); };
+    my @error_lines = split(/\n/, $@);
+    is(scalar(@error_lines), 3, "test verbose croak");
+    like($error_lines[0], qr!^'/not/a/valid/file' is not a regular file at!, "test verbose croak");
+    like($error_lines[1], qr!^\s*Dancer::Template::TemplateToolkit::render\('Dancer::Template::TemplateToolkit', '/not/a/valid/file'\) called at!, "test verbose croak stack trace");
+    like($error_lines[2], qr!^\s*eval {...} called at t/01_config/06_stack_trace.t!, "test verbose croak stack trace");
+}


### PR DESCRIPTION
As Carp is now used instead of die / warn, here is a new setting to control if stack traces should be displaed or not
