### PR TITLE
Fixed Redirect Issue + 

### DIFF
--- a/lib/Dancer.pm
+++ b/lib/Dancer.pm
@@ -662,6 +662,16 @@ You can also force Dancer to return a specific 300-ish HTTP response code:
     get '/old/:resource', sub {
         redirect '/new/'.params->{resource}, 301;
     };
+    
+It is important to note that issuing a redirect by itself does not exit and
+redirect immediately, redirection is deferred until after the current route
+or filter has been processed. To exit and redirect immediately, use the return
+function, e.g.
+
+    get '/restricted', sub {
+        return redirect '/login' if accessDenied();
+        return 'Welcome to the restricted section';
+    };
 
 =head2 request
 

--- a/lib/Dancer/Renderer.pm
+++ b/lib/Dancer/Renderer.pm
@@ -118,6 +118,14 @@ sub get_action_response {
         return get_action_response();
     }
 
+    # redirect immediately - skip route execution
+    if ($Dancer::Response::CURRENT->{status}){
+        if ($Dancer::Response::CURRENT->{status} == 302 ||
+            $Dancer::Response::CURRENT->{status} == 301) {
+                return serialize_response_if_needed(Dancer::Response->current);
+        }
+    }
+
     # execute the action
     if ($handler) {
 

--- a/lib/Dancer/Response.pm
+++ b/lib/Dancer/Response.pm
@@ -27,7 +27,8 @@ sub new {
 }
 
 # a singleton to store the current response
-my $CURRENT = Dancer::Response->new();
+# made public so status can be checked, etc
+our $CURRENT = Dancer::Response->new();
 
 # the accessor returns a copy of the singleton
 # after having purged it.


### PR DESCRIPTION
updated redirect function POD, redirect function will now exit without running any routes if called from within a before filter, etc
