### PR TITLE
Fix Dancer::Plugin @ISA screwage

### DIFF
--- a/lib/Dancer/Plugin.pm
+++ b/lib/Dancer/Plugin.pm
@@ -63,8 +63,9 @@ sub register_plugin {
     my @symbols = set_plugin_symbols($plugin);
     {
         no strict 'refs';
-        @{"${plugin}::ISA"} = ('Exporter', 'Dancer::Plugin');
-        @{"${plugin}::EXPORT"} = @symbols;
+        # tried to use unshift, but it yields an undef warning on $plugin (perl v5.12.1)
+        @{"${plugin}::ISA"} = ('Exporter', 'Dancer::Plugin', @{"${plugin}::ISA"});
+        push @{"${plugin}::EXPORT"}, @symbols;
     }
     return 1;
 }

--- a/t/15_plugins/05_plugins_and_OO.t
+++ b/t/15_plugins/05_plugins_and_OO.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use Test::More import => ['!pass'];
+plan tests => 2;
+
+{
+    use Dancer ':syntax';
+
+    # This plugin already inherits from Data::Dumper
+    use t::lib::TestPlugin2;
+    
+    load_app 't::lib::Forum';
+
+    # Make sure the keyword is well registerd
+    is(some_other_plugin_keyword(), 42, 'plugin keyword is exported');
+
+    # Make sure the plugin is still a Data::Dumper child
+    my $d = t::lib::TestPlugin2->new( [ 1, 2 ], [ qw(foo bar) ] );
+    is($d->Dump(), "\$foo = 1;\n\$bar = 2;\n");
+}

--- a/t/lib/TestPlugin2.pm
+++ b/t/lib/TestPlugin2.pm
@@ -1,0 +1,16 @@
+package t::lib::TestPlugin2;
+
+use strict;
+use warnings;
+
+use Dancer ':syntax';
+use Dancer::Plugin;
+
+use base qw(Data::Dumper);
+
+register some_other_plugin_keyword => sub {
+    42;
+};
+
+register_plugin;
+1;


### PR DESCRIPTION
Previously, Dancer::Plugin would overwrite the plugin's @ISA (and @EXPORT). Now it unshift 'Exporter' and 'Dancer::Plugin', hence keeping the Plugin inherit chain 
