### PR TITLE
documentation clarification

### DIFF
--- a/lib/Dancer.pm
+++ b/lib/Dancer.pm
@@ -387,11 +387,13 @@ them.
 Defines a before_template filter:
 
     before_template sub {
+        my $tokens = shift;
         # do something with request, vars or params
     };
 
 The anonymous function which is given to C<before_template> will be executed
-before sending data and tokens to the template.
+before sending data and tokens to the template. Receives a hashref of the
+tokens that will be inserted into the template.
 
 This filter works as the C<before> and C<after> filter.
 


### PR DESCRIPTION
Just thought it would be worthwhile to clarify that before_template receives the hashref of tokens.  Wasn't obvious to me until I looked at the cookbook.  Accept or reject as you will. :)  Just thought it would be a good idea.

Thanks again for Dancer. Trés Awesome.
