### PR TITLE
Get engine

### DIFF
--- a/lib/Dancer/Template/TemplateToolkit.pm
+++ b/lib/Dancer/Template/TemplateToolkit.pm
@@ -11,6 +11,8 @@ use base 'Dancer::Template::Abstract';
 
 my $_engine;
 
+sub get_engine { $_engine }
+
 sub init {
     my ($self) = @_;
 


### PR DESCRIPTION
provide an accessor for the Template engine

IMHO, there is no need to hide the Template object.
This allows one to do something like:

```
before sub {
    my $stash = Dancer::Template::TemplateToolkit
        ->get_engine->context->stash;
    $stash->set(base_url => uri_for('/'));
};
```

and even more TemplateToolkit power.
