### PR TITLE
Update IRC link in README

### DIFF
--- a/README
+++ b/README
@@ -23,7 +23,7 @@ See also the project on Github for the latest changes:
 http://github.com/sukria/Dancer
 
 To keep even more up to date and talk to the developers, join us in #dancer on
-irc.perl.org (if you don't have an IRC client, use http://www.perldancer.org/irc
+irc.perl.org (if you don't have an IRC client, use http://tiny.cc/dancerirc irc
 for easy access).
 
 === EXAMPLE ===


### PR DESCRIPTION
Fixed the IRC link in the README (however, might be better to fix the redirect from the original URL). Relates to https://github.com/sukria/Dancer/issues#issue/203
