### PR TITLE
Documentation/action skipping

### DIFF
--- a/lib/Dancer/Introduction.pod
+++ b/lib/Dancer/Introduction.pod
@@ -174,7 +174,7 @@ the request with the next matching route.
 This is done with the B<pass> keyword, like in the following example
 
     get '/say/:word' => sub {
-        pass if (params->{word} =~ /^\d+$/);
+        return pass if (params->{word} =~ /^\d+$/);
         "I say a word: ".params->{word};
     };
 


### PR DESCRIPTION
The Dancer::Introduction document contains an example using pass() but not following the recommendations from the reference documentation, i.e. returning immediately after having pass-ed.
