### PR TITLE
lib/Dancer/Development.pod minor fixes

### DIFF
--- a/lib/Dancer/Development.pod
+++ b/lib/Dancer/Development.pod
@@ -88,6 +88,7 @@ As a contributor, you should B<always> work on the C<devel> branch of
 your clone (C<master> is used only for building releases).
 
     $ git remote add upstream https://github.com/sukria/Dancer.git
+    $ git fetch upstream
     $ git checkout -b devel upstream/devel
 
 This will create a local branch in your clone named C<devel> and that


### PR DESCRIPTION
Turned one indentation tab into spaces and added a line to the contribution sequence in order to avoid errors when branching upstream/devel for the first time.
