### PR TITLE
Devel

### DIFF
--- a/lib/Dancer/Session/YAML.pm
+++ b/lib/Dancer/Session/YAML.pm
@@ -9,6 +9,7 @@ use Dancer::Logger;
 use Dancer::ModuleLoader;
 use Dancer::Config 'setting';
 use Dancer::FileUtils qw(path open_file);
+use File::Copy;
 
 # static
 
@@ -56,6 +57,11 @@ sub yaml_file {
     return path(setting('session_dir'), "$id.yml");
 }
 
+sub tmp_yaml_file {
+    my ($id) = @_;
+    return path(setting('session_dir'), "$id.tmp");
+}
+
 sub destroy {
     my ($self) = @_;
     use Dancer::Logger;
@@ -66,9 +72,10 @@ sub destroy {
 
 sub flush {
     my $self = shift;
-    my $sessionfh = open_file('>', yaml_file($self->id));
+    my $sessionfh = open_file('>', tmp_yaml_file($self->id));
     print {$sessionfh} YAML::Dump($self);
     close $sessionfh;
+    move(tmp_yaml_file($self->id), yaml_file($self->id));
     return $self;
 }
 


### PR DESCRIPTION
Session::YAML bug fix.

It is possible to read an empty session while it's being
overwritten by another process, what cause mysterious errors.
It is better to write a session content to a temporary file and then
to replace existing session file.
