### PR TITLE
Pr/code not status

### DIFF
--- a/lib/Dancer/Route.pm
+++ b/lib/Dancer/Route.pm
@@ -227,7 +227,7 @@ sub execute {
         my $content = $self->code->();
         if ($warning) {
             return Dancer::Error->new(
-                status  => 500,
+                code    => 500,
                 message => "Warning caught during route execution: $warning",
             )->render;
         }


### PR DESCRIPTION
It seems that Dancer::Error accepts a "code", not a "status" parameter. This is the root cause of http://lists.perldancer.org/pipermail/dancer-users/2011-January/000887.html - the problem can be replicated when using plackup with Shotgun (the OP told me in a private message). Tests run OK.
