### PR TITLE
Allow setting JSON serializer options with set serializer => ...

### DIFF
--- a/lib/Dancer/Serializer.pm
+++ b/lib/Dancer/Serializer.pm
@@ -24,6 +24,10 @@ sub engine {
 
 sub init {
     my ($class, $name, $config) = @_;
+    if (ref $name eq 'ARRAY') {
+        $config = { engines => { $name->[0] => $name->[1] } };
+        $name   = $name->[0];
+    }
     $name ||= 'JSON';
     $_engine = Dancer::Engine->build('serializer' => $name, $config);
     return $_engine;

--- a/lib/Dancer/Serializer/JSON.pm
+++ b/lib/Dancer/Serializer/JSON.pm
@@ -25,13 +25,17 @@ sub to_json {
 sub loaded { Dancer::ModuleLoader->load('JSON') }
 
 sub init {
-    my ($self) = @_;
+    my ($self, %p) = @_;
     croak 'JSON is needed and is not installed'
       unless $self->loaded;
+
+    $self->{options} = $p{config};
 }
 
 sub serialize {
     my ($self, $entity, %options) = @_;
+
+    %options = (%{ $self->{options} }, %options) if $self->{options}; 
 
     # Why doesn't $self->config have this?
     my $config = setting('engines') || {};
@@ -86,6 +90,9 @@ extra settings to the B<engines> configuration to turn these on.
             allow_blessed: '1'
             convert_blessed: '1'
 
+To set these options in your app code, use
+
+    set serializer => [ 'JSON', { convert_blessed => 1 } ];
 
 =head2 METHODS
 

--- a/t/14_serializer/02_json.t
+++ b/t/14_serializer/02_json.t
@@ -5,7 +5,7 @@ use Dancer;
 
 plan skip_all => "JSON is needed to run this tests"
     unless Dancer::ModuleLoader->load('JSON');
-plan tests => 14;
+plan tests => 16;
 
 eval {
     setting serializer => 'FooBar';
@@ -41,6 +41,15 @@ $json = to_json($data, pretty => 1);
 like $json, qr/"foo" : {/, "data is pretty!";
 $data2 = from_json($json);
 is_deeply($data2, $data, "data is correctly deserialized");
+
+
+ok(setting('serializer' => [ 'JSON' => { allow_blessed => 1, convert_blessed => 1 } ]), "serializer JSON loaded with options");
+sub TO_JSON { +{ %{shift()} } }
+$s = Dancer::Serializer->engine;
+$data = bless { foo => 'bar' };
+$json = $s->serialize($data);
+is $json, '{"foo":"bar"}', "data is correctly serialized";
+
 
 my $config = {
     engines => {


### PR DESCRIPTION
(as posted on IRC)

A better solution would be based on changing the 'set' mechanism to allow more values than a simple scalar to be set; but at least for me this is immediately useful (and has tests).
