### PR TITLE
read_file_content should return array in array context.

### DIFF
--- a/lib/Dancer/FileUtils.pm
+++ b/lib/Dancer/FileUtils.pm
@@ -67,12 +67,13 @@ Dancer::FileUtils - helper providing file utilities
     use Dancer::FileUtils qw/path read_file_content/;
 
     my $content = read_file_content( path( 'folder', 'folder', 'file' ) );
+    my @content = read_file_content( path( 'folder', 'folder', 'file' ) );
 
 =head1 DESCRIPTION
 
-Dancer::FileUtils encompasses a few utilities that relate to files which Dancer
-uses. Developers may use it instead of writing their own little subroutines or
-use additional modules.
+Dancer::FileUtils includes a few file related utilities related that Dancer
+uses internally. Developers may use it instead of writing their own
+file reading subroutines or using additional modules.
 
 =head1 SUBROUTINES/METHODS
 
@@ -106,9 +107,13 @@ a path.
     use Dancer::FileUtils 'read_file_content';
 
     my $content = read_file_content($file);
+    my @content = read_file_content($file);
 
-Returns either the content of a file (whose filename is the input) or I<undef>
-in case it failed to open the file.
+Returns either the content of a file (whose filename is the input), I<undef>
+if the file could not be opened.
+
+In array context it returns each line (as defined by $/) as a seperate element
+Scalar context returns the entire contents of the file.
 
 =head2 read_glob_content
 
@@ -116,6 +121,7 @@ in case it failed to open the file.
 
     open my $fh, '<', $file or die "$!\n";
     my $content = read_glob_content($fh);
+    my @content = read_glob_content($fh);
 
 Same as I<read_file_content>, only it accepts a file handle.
 

--- a/t/00_base/11_file_utils.t
+++ b/t/00_base/11_file_utils.t
@@ -1,10 +1,24 @@
-use strict;
-use warnings;
-use Test::More;
+use Test::More import => ['!pass'];
+use File::Spec;
+use File::Temp;
 
-plan tests => 1;
-
+use Dancer ':syntax';
 use Dancer::FileUtils qw/read_file_content/;
 
-my $content = read_file_content();
-ok !$content;
+use lib File::Spec->catdir( 't', 'lib' );
+use TestUtils;
+
+use strict;
+use warnings;
+
+plan tests => 2;
+
+
+my $tmp = File::Temp->new();
+write_file($tmp, "one$/two");
+
+my $content = read_file_content($tmp);
+ok $content = "one$/two";
+
+my @content = read_file_content($tmp);
+ok $content[0] eq "one$/" && $content[1] eq 'two';


### PR DESCRIPTION
It would be nice if read_file_content would return the file contents as an array if called in that context.

read_glob_content is called when doing send_file, and it's always called in a scalar context, so read_glob_content should change too.

Passes tests as far as I can tell. Hope pull request is done right, followed the docs on cpan.
