### PR TITLE
after_action_error

### DIFF
--- a/lib/Dancer.pm
+++ b/lib/Dancer.pm
@@ -36,6 +36,7 @@ use base 'Exporter';
 
 @EXPORT    = qw(
   after
+  after_action_error
   any
   before
   before_template
@@ -100,6 +101,7 @@ use base 'Exporter';
 # Dancer's syntax
 
 sub after           { Dancer::Route::Registry->hook('after',           @_) }
+sub after_action_error { Dancer::Route::Registry->hook('after_action_error', @_) }
 sub any             { Dancer::App->current->registry->any_add(@_) }
 sub before          { Dancer::Route::Registry->hook('before',          @_) }
 sub before_template { Dancer::Route::Registry->hook('before_template', @_) }

--- a/lib/Dancer/Error.pm
+++ b/lib/Dancer/Error.pm
@@ -16,6 +16,8 @@ sub new {
     my $self = \%params;
     bless $self, $class;
 
+    $_->( $self ) for @{ Dancer::App->current->registry->hooks->{after_action_error} };
+
     $self->{title} ||= "Error " . $self->code;
     $self->{type}  ||= "runtime error";
 

--- a/lib/Dancer/Renderer.pm
+++ b/lib/Dancer/Renderer.pm
@@ -83,6 +83,21 @@ sub html_page {
 }
 
 sub get_action_response {
+    my $response = eval { determine_action_response() };
+    if ($@) {
+        my $request = Dancer::SharedData->request;
+        Dancer::Logger::core('requested action ' . $request->path_info . " crashed: $@");
+        my $error = Dancer::Error->new(
+            code    => 500,
+            title   => "Action Runtime Error",
+            message => $@
+        );
+        $response = $error->render;
+    }
+    return $response;
+}
+
+sub determine_action_response {
     my $response;
 
     # save the request before the filters are ran

--- a/t/17_apps/06_after_action_error.t
+++ b/t/17_apps/06_after_action_error.t
@@ -1,0 +1,12 @@
+use strict; use warnings;
+use Test::More tests => 2, import => ['!pass'];
+
+use Dancer::Test;
+
+use lib ('t/lib');
+use TestApp;
+
+use Dancer ':syntax';
+
+response_status_is [GET => "/send_error"], 599;
+response_status_is [GET => "/die"], 599;

--- a/t/lib/TestApp.pm
+++ b/t/lib/TestApp.pm
@@ -71,4 +71,17 @@ get '/unicode' => sub {
     "cyrillic shcha \x{0429}",
 };
 
+after_action_error sub {
+      my $error = shift;
+        $error->{code} = 599;
+};
+
+get '/send_error' => sub {
+       send_error('Ouch!','500'); 
+};
+
+get '/die' => sub {
+        die 'mein Leben';
+};
+
 true;


### PR DESCRIPTION
This is an updated pull request to replace #300 ( and maybe #301 ). I've renamed my hook to after_action_error, because you guys didn't like the "on_error" name, and because this is more specifically working only on actions (not files). 

I still agree with the reason for hooks/mapping, and still think that's the way to go as outlined in #301. However, I wanted to submit this patch because it actually handles my problem area.

The problem I was having was that "die" wasn't being caught/handled correctly. It turns out that's because Dancer::Test calls Dancer::Renderer::get_action_response directly, so the on_error hook I implemented in #300 was never being triggered on a die.

I'm certain that there's a better way to build this, and that through your mapping/hooks project this weekend you'll implement this in a fantastic way. But now you know exactly what problem needs to be solved. Please do ask questions if you have any. I'm happy to provide more detail if needed.
