### PR TITLE
HTTP::Headers minimum version requirement for tests to complete

### DIFF
--- a/t/12_response/04_charset_server.t
+++ b/t/12_response/04_charset_server.t
@@ -5,10 +5,17 @@ use Dancer::ModuleLoader;
 use Dancer;
 use Encode;
 
+# Ensure a recent version of HTTP::Headers
+my $min_hh = 5.827;
+eval "use HTTP::Headers $min_hh";
+plan skip_all => "HTTP::Headers $min_hh required for tests (use of content_type_charset)"
+    if $@;
+
 plan skip_all => "HTTP::Request::Common is needed for this test"
     unless Dancer::ModuleLoader->load('HTTP::Request::Common');
 plan skip_all => "Test::TCP is needed for this test"
     unless Dancer::ModuleLoader->load("Test::TCP");
+
 
 use LWP::UserAgent;
 


### PR DESCRIPTION
Some versions of OS X have an old version of HTTP::Headers that doesn't have the content_type_charset method. This means the tests fail when installing Dancer on them. This just fixes the test so that it requires a minimum version - in this case the first version that has this method, as listed in the changes file for HTTP::Headers.

content_type_charset is only ever used in the tests, not anywhere else in Dancer core. So not sure if fixing the test this way, or fixing the test by removing the use of content_type_charset is the way forward. This seems easier to me.
