### PR TITLE
Re-fix GH#136 after introduction of Dancer::MIME.

### DIFF
--- a/lib/Dancer/MIME.pm
+++ b/lib/Dancer/MIME.pm
@@ -6,6 +6,15 @@ use base 'Dancer::Object::Singleton';
 
 use MIME::Types;
 
+# Initialise MIME::Types at compile time, to ensure it's done before
+# the fork in a preforking webserver like mod_perl or Starman. Not
+# doing this leads to all MIME types being returned as "text/plain",
+# as MIME::Types fails to load its mappings from the DATA handle. See
+# t/04_static_file/003_mime_types_reinit.t and GH#136.
+BEGIN {
+        MIME::Types->new(only_complete => 1);
+}
+
 __PACKAGE__->attributes( qw/mime_type aliases/ );
 
 sub init {

--- a/t/04_static_file/003_mime_types_reinit.t
+++ b/t/04_static_file/003_mime_types_reinit.t
@@ -1,0 +1,46 @@
+use strict;
+use warnings;
+
+use IO::Handle;
+
+use Dancer::MIME;
+use Dancer ':syntax';
+use Dancer::ModuleLoader;
+
+use Test::More import => ['!pass'];
+
+plan tests => 3;
+
+# Test that MIME::Types gets initialised before the fork, as it'll
+# fail to read from DATA in all bar one child process in a
+# mod_perl-type preforking situation.
+#
+# See the comment near the top of Dancer/MIME.pm, and GH#136. 
+
+my @cts;
+for (my $i = 0; $i < 3; $i++) {
+        my ($p, $c) = (IO::Handle->new, IO::Handle->new);
+        pipe($p, $c);
+
+        if (my $pid = fork()) {
+                # parent
+                $c->close;
+                my $ct = $p->getline;
+                $p->close();
+                waitpid($pid, 0);
+                push @cts, $ct;
+        }
+        else {
+                # child
+                $p->close;
+                my $mime = Dancer::MIME->instance();
+                my $type = $mime->mime_type_for('css');
+                $c->print($type);
+                $c->close;
+                exit 0;
+        }
+}
+
+ok($cts[0] eq 'text/css');
+ok($cts[1] eq 'text/css');
+ok($cts[2] eq 'text/css');


### PR DESCRIPTION
Per my comment on GH#136, here's a patch which re-adds the initialisation of MIME::Types in Dancer::MIME, and a test which shows the effect of the change on forking webserver situations. 

This fixes an issue I noticed where static content would be served with a content-type of text/plain by all but one worker process, rather than the appropriate content-type, when running under Starman with the --preload-app switch.
