### PR TITLE
Pr/path fix create Add path_no_verify() for use when path() fails on file non-existence

### DIFF
--- a/lib/Dancer.pm
+++ b/lib/Dancer.pm
@@ -261,14 +261,14 @@ sub _init {
       || setting('appdir');
 
     setting public => $ENV{DANCER_PUBLIC}
-      || path_no_verify(setting('appdir'), 'public');
+      || Dancer::FileUtils::path_no_verify(setting('appdir'), 'public');
 
     setting views => $ENV{DANCER_VIEWS}
-      || path_no_verify(setting('appdir'), 'views');
+      || Dancer::FileUtils::path_no_verify(setting('appdir'), 'views');
 
     setting logger => 'file';
 
-    my ($res, $error) = Dancer::ModuleLoader->use_lib(path_no_verify(setting('appdir'), 'lib'));
+    my ($res, $error) = Dancer::ModuleLoader->use_lib(Dancer::FileUtils::path_no_verify(setting('appdir'), 'lib'));
     $res or croak "unable to set libdir : $error";
 }
 

--- a/lib/Dancer/FileUtils.pm
+++ b/lib/Dancer/FileUtils.pm
@@ -6,6 +6,7 @@ use warnings;
 use File::Basename ();
 use File::Spec;
 use Carp;
+use Cwd 'realpath';
 
 use base 'Exporter';
 use vars '@EXPORT_OK';
@@ -13,7 +14,7 @@ use vars '@EXPORT_OK';
 @EXPORT_OK = qw(path dirname read_file_content read_glob_content open_file);
 
 sub path           { File::Spec->catfile(@_) }
-sub path_no_verify { File::Spec->catdir(@_[0...$#_-1]).File::Spec->catdir('').$_[-1] } # [0->?] path(must exist),[last] file(maybe exists)
+sub path_no_verify { realpath(File::Spec->catdir(@_[0..$#_-1])).'/'.$_[-1] } # [0->?] path(must exist),[last] file(maybe exists)
 sub dirname        { File::Basename::dirname(@_) }
 
 sub open_file {

--- a/t/02_request/14_uploads.t
+++ b/t/02_request/14_uploads.t
@@ -3,6 +3,7 @@ use warnings;
     
 use Dancer ':syntax';
 use Dancer::Request;
+use Dancer::FileUtils;
 use Test::More 'import' => ['!pass'];
 
 
@@ -95,8 +96,8 @@ do {
     $upload->copy_to($dest_file);
     ok( ( -f $dest_file ), "file '$dest_file' has been copied" );
 
-    $upload->link_to( path_no_verify( $dest_dir, "hardlink" ) );
-    ok( ( -f path_no_verify( $dest_dir, "hardlink" ) ), "hardlink is created" );
+    $upload->link_to( Dancer::FileUtils::path_no_verify( $dest_dir, "hardlink" ) );
+    ok( ( -f Dancer::FileUtils::path_no_verify( $dest_dir, "hardlink" ) ), "hardlink is created" );
 
   SKIP: {
         skip "bogus upload tests on win32", 2 if ( $^O eq 'MSWin32' or $^O eq 'cygwin'  );


### PR DESCRIPTION
- Add path_no_verify() for use when path() fails on file non-existence
- Fix "views" "public" and "lib" check in Dancer.pm to use it
- Unmask  a test which now works because of it, and use it there.
