### PR TITLE
pr/mixed-unc-scriptdir-volname-tests-fix Fix anti UNC substitution, log-file creation, lack-of-volname handling, parent-dir

### DIFF
--- a/lib/Dancer.pm
+++ b/lib/Dancer.pm
@@ -238,7 +238,12 @@ sub _init {
     my ($script_vol, $script_dirs, $script_name) =
       File::Spec->splitpath(File::Spec->rel2abs($script));
     my @script_dirs = File::Spec->splitdir($script_dirs);
-    my $script_path = Dancer::FileUtils::d_catdir($script_vol, $script_dirs);
+    my $script_path;
+    if ($script_vol) {
+        $script_path = path($script_vol, $script_dirs);
+    } else {
+        $script_path = path($script_dirs);
+    }
 
     my $LAYOUT_PRE_DANCER_1_2 = 1;
 
@@ -251,7 +256,7 @@ sub _init {
       || (
           $LAYOUT_PRE_DANCER_1_2
         ? $script_path
-        : File::Spec->rel2abs(path($script_path, '..'))
+        : File::Spec->rel2abs(path($script_path, File::Spec->updir()))
       );
 
     # once the dancer_appdir have been defined, we export to env

--- a/lib/Dancer/Logger/File.pm
+++ b/lib/Dancer/Logger/File.pm
@@ -4,7 +4,7 @@ use warnings;
 use Carp;
 use base 'Dancer::Logger::Abstract';
 
-use File::Spec;
+use File::Temp qw/tempdir/;
 use Dancer::Config 'setting';
 use Dancer::FileUtils qw(open_file);
 use IO::File;
@@ -12,12 +12,23 @@ use IO::File;
 sub logdir {
     my $altpath = setting('log_path');
     return $altpath if($altpath);
-    my $appdir = setting('appdir');
-    my $logroot = $appdir;
-    unless($logroot) {
-        $logroot = Dancer::FileUtils::d_canonpath(File::Spec->tmpdir().'/dancer-'.$$);
-        if (!-d $logroot and not mkdir $logroot) {
-            carp "log directory $logroot doesn't exist, unable to create";
+    my $logroot = setting('appdir');
+    if ($logroot) {
+        if (!-d $logroot && not mkdir $logroot) {
+            carp "log directory $logroot doesn't exist, am unable to create it";
+            return;
+        }
+    } else {
+        unless($logroot = tempdir(CLEANUP => 1, TMPDIR => 1)) {
+            carp "cannot create temp log directory";
+            return;
+        }
+    }
+    unless (-w $logroot and -x $logroot) {
+        my $perm = (stat $logroot)[2] & 07777;
+        chmod($perm | 0700, $logroot);
+        unless (-w $logroot and -x $logroot) {
+            carp "log directory $logroot isn't writable/executable and can't chmod it";
             return;
         }
     }
@@ -27,23 +38,16 @@ sub logdir {
 sub init {
     my ($self) = @_;
     my $logdir = logdir();
-
-    if (!-d $logdir && not mkdir $logdir) {
-        carp "log directory $logdir doesn't exist, unable to create";
-        return;
-    }
-    if (!-w $logdir or !-x $logdir) {
-        my $perm = (stat $logdir)[2] & 07777;
-        chmod($perm | 0700, $logdir);
-        carp "log directory $logdir isn't writable/executable, can't chmod it";
-        return;
-    }
-
+    return unless ($logdir);
     my $logfile = setting('environment');
-    $logfile = Dancer::FileUtils::path_no_verify($logdir, "$logfile.log");
 
-    my $fh = open_file('>>', $logfile) or carp "unable to create or append to $logfile";
-
+    mkdir($logdir) unless(-d $logdir);
+    $logfile = File::Spec->catfile($logdir, "$logfile.log");
+    my $fh;
+    unless($fh = open_file('>>', $logfile)) {
+        carp "unable to create or append to $logfile";
+        return;
+    }
     $fh->autoflush;
     $self->{logfile} = $logfile;
     $self->{fh} = $fh;

--- a/t/01_config/04_config_file.t
+++ b/t/01_config/04_config_file.t
@@ -12,7 +12,7 @@ use File::Spec;
 use lib File::Spec->catdir( 't', 'lib' );
 use TestUtils;
 
-my $dir = tempdir(CLEANUP => 1);
+my $dir = tempdir(CLEANUP => 1, TMPDIR => 1);
 set appdir => $dir;
 my $envdir = File::Spec->catdir($dir, 'environments');
 mkdir $envdir;

--- a/t/01_config/06_config_api.t
+++ b/t/01_config/06_config_api.t
@@ -16,7 +16,7 @@ eval {
 
 like $@, qr/Unable to parse the configuration file/;
 
-my $dir = tempdir(CLEANUP => 1);
+my $dir = tempdir(CLEANUP => 1, TMPDIR => 1);
 
 my $config_file = File::Spec->catfile($dir, 'settings.yml');
 

--- a/t/03_route_handler/07_compilation_warning.t
+++ b/t/03_route_handler/07_compilation_warning.t
@@ -7,7 +7,7 @@ use Dancer ':syntax';
 use Dancer::Logger;
 use File::Temp qw/tempdir/;
 
-my $dir = tempdir(CLEANUP => 1);
+my $dir = tempdir(CLEANUP => 1, TMPDIR => 1);
 set appdir => $dir;
 Dancer::Logger->init('File');
 

--- a/t/03_route_handler/11_redirect.t
+++ b/t/03_route_handler/11_redirect.t
@@ -7,7 +7,7 @@ use Dancer::Logger;
 use File::Temp qw/tempdir/;
 use Dancer::Test;
 
-my $dir = tempdir(CLEANUP => 1);
+my $dir = tempdir(CLEANUP => 1, TMPDIR => 1);
 set appdir => $dir;
 Dancer::Logger->init('File');
 

--- a/t/03_route_handler/29_forward.t
+++ b/t/03_route_handler/29_forward.t
@@ -7,7 +7,7 @@ use Dancer::Logger;
 use File::Temp qw/tempdir/;
 use Dancer::Test;
 
-my $dir = tempdir(CLEANUP => 1);
+my $dir = tempdir(CLEANUP => 1, TMPDIR => 1);
 set appdir => $dir;
 Dancer::Logger->init('File');
 

--- a/t/08_session/03_http_requests.t
+++ b/t/08_session/03_http_requests.t
@@ -15,7 +15,7 @@ use LWP::UserAgent;
 
 use File::Spec;
 use File::Temp 'tempdir';
-my $tempdir = tempdir('Dancer.XXXXXX', DIR => File::Spec->curdir, CLEANUP => 1);
+my $tempdir = tempdir(CLEANUP => 1, TMPDIR => 1);
 
 use Dancer;
 use Dancer::Logger;

--- a/t/08_session/05_yaml.t
+++ b/t/08_session/05_yaml.t
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 
-my $dir = tempdir(CLEANUP => 1);
+my $dir = tempdir(CLEANUP => 1, TMPDIR => 1);
 set appdir => $dir;
 
 my $session = Dancer::Session::YAML->create();

--- a/t/09_cookies/03_persistence.t
+++ b/t/09_cookies/03_persistence.t
@@ -14,7 +14,7 @@ use Dancer;
 
 use File::Spec;
 use File::Temp 'tempdir';
-my $tempdir = tempdir('Dancer.XXXXXX', DIR => File::Spec->curdir, CLEANUP => 1);
+my $tempdir = tempdir(CLEANUP => 1, TMPDIR => 1);
 
 plan tests => 9;
 Test::TCP::test_tcp(

--- a/t/11_logger/02_factory.t
+++ b/t/11_logger/02_factory.t
@@ -7,7 +7,7 @@ use t::lib::TestUtils;
 use File::Temp qw/tempdir/;
 use Dancer ':syntax';
 
-my $dir = tempdir(CLEANUP => 1);
+my $dir = tempdir(CLEANUP => 1, TMPDIR => 1);
 setting appdir => $dir;
 
 use_ok 'Dancer::Logger';

--- a/t/11_logger/03_file.t
+++ b/t/11_logger/03_file.t
@@ -7,7 +7,7 @@ use File::Temp qw/tempdir/;
 use t::lib::TestUtils;
 use Dancer;
 
-my $dir = tempdir(CLEANUP => 1);
+my $dir = tempdir(CLEANUP => 1, TMPDIR => 1);
 setting appdir => $dir;
 
 use_ok 'Dancer::Logger::File';
@@ -28,7 +28,7 @@ ok($l->warning("Perl Dancer test message 3/4"), "warning works");
 ok($l->error("Perl Dancer test message 4/4"), "error works");
 
 #Create a new tmp directory to test log_path option
-my $dir2 = tempdir(CLEANUP => 1);
+my $dir2 = tempdir(CLEANUP => 1, TMPDIR => 1);
 setting log_path => $dir2;
 
 is(Dancer::Logger::File->logdir, $dir2, 

--- a/t/15_plugins/02_config.t
+++ b/t/15_plugins/02_config.t
@@ -15,7 +15,7 @@ use TestUtils;
 
 use File::Temp qw/tempdir/;
 
-my $dir = tempdir(CLEANUP => 1);
+my $dir = tempdir(CLEANUP => 1, TMPDIR => 1);
 set(appdir => $dir);
 set(confdir => $dir);
 mkdir File::Spec->catdir( $dir, 'environments' );

--- a/t/19_dancer/01_script.t
+++ b/t/19_dancer/01_script.t
@@ -24,7 +24,7 @@ sub slurp {
     <$fh>;
 }
 
-my $dir = tempdir( CLEANUP => 1 );
+my $dir = tempdir(CLEANUP => 1, TMPDIR => 1);
 my $cwd = cwd;
 
 chdir $dir;

--- a/t/19_dancer/02_script_version_from.t
+++ b/t/19_dancer/02_script_version_from.t
@@ -12,7 +12,7 @@ my %cases = (
     'A::B' => [ 'A-B', 'lib/A/B.pm' ],
 );
 
-my $dir = tempdir( CLEANUP => 1 );
+my $dir = tempdir(CLEANUP => 1, TMPDIR => 1);
 my $cwd = cwd;
 
 chdir $dir;


### PR DESCRIPTION
<pre>
NB: These patches are combined because separately each one exposes bugs and failed tests for
the other, but combined they solve each other's problems :-)
They include patches from previous pull requests which have been superceded (I will close those
requests now).
</pre>

- Dancer.pm
  
  -> Added handling for absent vol-name (e.g. in unix) which prevents catdir()/etc creating double-leading-slashes.
  
  -> Used a more portable syntax for parent directory
- Dancer::FileUtils
  
  -> Created _trim_UNC() -> reusable, more robust, faster anti-UNC-substitution.
  
  -> Used splitpath in path_no_verify() -> simpler, faster and more fault-tolerant path calculation.
- Dancer::Logger::File
  
  -> Rewrote logfile creation functions -> more fault-tolerant, cleaner, faster.
  
  -> Used tempdir() for temp-log-file creation -> replace previous hackish methods.
  
  -> Removed double-carp error (when logdir doesn't exist).
- t/02_request/14_uploads.t
  
  -> Unmask all but the one remaining masked test for Win32. Include a note explaining why the remaining test fails on Win32.
- many files
  
  -> Forced the TMPDIR => 1 option for tempdir(), so Win32 behaves.
