### PR TITLE
Allow subclasses of Template Toolkit to be used

### DIFF
--- a/lib/Dancer/Template/TemplateToolkit.pm
+++ b/lib/Dancer/Template/TemplateToolkit.pm
@@ -14,8 +14,9 @@ my $_engine;
 sub init {
     my ($self) = @_;
 
-    croak "Template is needed by Dancer::Template::TemplateToolkit"
-      unless Dancer::ModuleLoader->load('Template');
+    my $class = $self->config->{subclass} || "Template";
+    croak "$class is needed by Dancer::Template::TemplateToolkit"
+      if !$class->can("process") and !Dancer::ModuleLoader->load($class);
 
     my $charset = setting('charset') || '';
     my @encoding = length($charset) ? ( ENCODING => $charset ) : ();
@@ -40,7 +41,7 @@ sub init {
 
     $tt_config->{INCLUDE_PATH} = setting('views');
 
-    $_engine = Template->new(%$tt_config);
+    $_engine = $class->new(%$tt_config);
 }
 
 sub render {
@@ -88,6 +89,13 @@ within your config file - for example:
         template_toolkit:
             start_tag: '[%'
             stop_tag: '%]'
+
+By default, L<Template> is used, but you can configure Dancer to use a
+subclass with the C<subclass> option.
+
+    engines:
+        template_toolkit:
+            subclass: My::Template
 
 
 =head1 SEE ALSO

--- a/t/10_template/05_template_toolkit.t
+++ b/t/10_template/05_template_toolkit.t
@@ -21,6 +21,9 @@ my $mock = { 'Template' => 0 };
 mock 'Dancer::ModuleLoader'
     => method 'load'
     => should sub { $mock->{ $_[1] } };
+mock 'Template'
+    => method 'can'
+    => should sub { 0 };
 
 my $engine;
 eval { $engine = Dancer::Template::TemplateToolkit->new };


### PR DESCRIPTION
Hi,
This patch allows Dancer's template toolkit engine to be configured to use a subclass of Template, rather than having it hard coded.

I found this useful because I'm converting an existing app to Dancer.  It has its own subclass of Template.  Eventually I'll get rid of it, but for now it's simpler to just continue to use it.

Thanks,
Schwern
