### PR TITLE
When template is not found, show a meaningful error message

### DIFF
--- a/lib/Dancer/Template/Abstract.pm
+++ b/lib/Dancer/Template/Abstract.pm
@@ -46,7 +46,6 @@ sub apply_renderer {
     ($tokens, undef) = _prepare_tokens_options($tokens);
 
     $view = $self->view($view);
-    -r $view or return;
 
     $_->($tokens) for (@{Dancer::App->current->registry->hooks->{before_template}});
 


### PR DESCRIPTION
When show_errors: 1,

If a layout template file is not found, Dancer reports
correctly that it's not found.  However, if a regular template file is
not found, the error message is meaningless.
Error 404
runtime error

Page not found

Here is a patch that allows Dancer::Template to return a meaningful
error message when a regular template file is not found.  I removed a check to see if the template file was readable.  This essentially leaves it up to the render() method to check for errors, which it already does, and to report errors, which it already does.  The act of returning nothing is what
covers up the real error.
