### PR TITLE
Add Dancer::Request::Upload->type

### DIFF
--- a/lib/Dancer/Request/Upload.pm
+++ b/lib/Dancer/Request/Upload.pm
@@ -58,6 +58,14 @@ sub basename {
     File::Basename::basename($self->filename);
 }
 
+sub type {
+    my $self = shift;
+
+    return $self->headers->{'Content-Type'};
+}
+
+
+
 # private
 
 =pod
@@ -111,6 +119,18 @@ Copies the temporary file using File::Copy. Returns true for success,
 false for failure.
 
     $upload->copy_to('/path/to/target')
+
+=item size
+
+The size of the upload, in bytes.
+
+=item headers
+
+Returns a hash ref of the headers associated with this upload.
+
+=item type
+
+The Content-Type of this upload.
 
 =back
 

--- a/t/02_request/14_uploads.t
+++ b/t/02_request/14_uploads.t
@@ -13,7 +13,6 @@ sub test_path {
     is dirname($file), $dir, "dir of $file is $dir";
 }
 
-plan tests => 16;
 
 my $content = qq{------BOUNDARY
 Content-Disposition: form-data; name="test_upload_file"; filename="yappo.txt"
@@ -76,11 +75,14 @@ do {
     is $req->uploads->{'test_upload_file4'}[0]->content, 'SHOGUN4',
       "... content for other also good";
 
-    # headers
+    note "headers";
     is_deeply $uploads[0]->headers, {
         'Content-Disposition' => q[form-data; name="test_upload_file"; filename="yappo.txt"],
         'Content-Type'        => 'text/plain',
     };
+
+    note "type";
+    is $uploads[0]->type, 'text/plain';
 
     my $test_upload_file3 = $req->upload('test_upload_file3');
     is $test_upload_file3->content, 'SHOGUN3',
@@ -119,3 +121,4 @@ do {
     unlink($file) if ($^O eq 'MSWin32');
 };
 
+done_testing;


### PR DESCRIPTION
Hi,
I noticed Dancer::Request::Upload has no documented way to get the content-type of the upload.  It's available in the undocumented headers() method.

This pull...
- documents size()
- documents (and tests) headers()
- implement, document and test a type() convenience method

I wasn't sure how to usefully test size.
