### PR TITLE
Make Dancer::Test use the capture logger

### DIFF
--- a/lib/Dancer/Test.pm
+++ b/lib/Dancer/Test.pm
@@ -40,6 +40,8 @@ use vars '@EXPORT';
 
   dancer_response
   get_response
+
+  read_logs
 );
 
 sub import {
@@ -261,6 +263,11 @@ sub _get_handler_response {
     return Dancer::Handler->handle_request($request);
 }
 
+sub read_logs {
+    return Dancer::Logger::Capture->trap->read;
+}
+
+
 1;
 __END__
 
@@ -414,6 +421,32 @@ Schrodinger's cat to die.
 =head2 get_response([$method, $path])
 
 This method is B<DEPRECATED>.  Use dancer_response() instead.
+
+
+=head2 read_logs
+
+    my $logs = read_logs;
+
+Returns an array ref of all log messages issued by the app since the
+last call to C<read_logs>.
+
+For example:
+
+    warning "Danger!  Warning!";
+    debug   "I like pie.";
+
+    is_deeply read_logs, [
+        { level => "warning", message => "Danger!  Warning!" },
+        { level => "debug",   message => "I like pie.", }
+    ];
+
+    error "Put out the light.";
+
+    is_deeply read_logs, [
+        { level => "error", message => "Put out the light." },
+    ];
+
+See L<Dancer::Logger::Capture> for more details.
 
 =head1 LICENSE
 

--- a/t/00_base/dancer_test.t
+++ b/t/00_base/dancer_test.t
@@ -1,4 +1,4 @@
-use Test::More import => ['!pass'], tests => 21;
+use Test::More import => ['!pass'], tests => 22;
 
 use strict;
 use warnings;
@@ -64,9 +64,17 @@ note "capture logs"; {
     is setting("logger"), "capture";
     is setting("log"),    "debug";
 
-    my $msg = "Either that wallpaper goes, or I do.";
-    error $msg;
-    is_deeply +Dancer::Logger::Capture->trap->read, [
-        { level   => "error", message => $msg }
-    ];
+    warning "Danger!  Warning!";
+    debug   "I like pie.";
+
+    is_deeply read_logs, [
+        { level => "warning", message => "Danger!  Warning!" },
+        { level => "debug",   message => "I like pie.", }
+    ], "read_logs";
+
+    error "Put out the light.";
+
+    is_deeply read_logs, [
+        { level => "error", message => "Put out the light." },
+    ], "each read clears the trap";
 }


### PR DESCRIPTION
This makes Dancer::Test use Dancer::Logger::Capture and adds a read_logs convenience method.  This will make it more likely that people will test their log messages.  If they don't, it's no worse than the null logger.
