### PR TITLE
Pr/cookbook structure

### DIFF
--- a/lib/Dancer/Cookbook.pod
+++ b/lib/Dancer/Cookbook.pod
@@ -7,7 +7,9 @@ Dancer::Cookbook - a quick-start guide to the Dancer web framework
 A quick-start guide with examples to get you up and running with the Dancer web
 framework.
 
-=head1 RECIPES
+
+
+=head1 BEGINNER'S DANCE
 
 =head2 Your first Dancer web app
 
@@ -38,6 +40,8 @@ route specification, whose value is made available through C<params>
 
 Note that you don't need to use the C<strict> and C<warnings> pragma, they are
 already loaded by Dancer.
+
+
 
 =head2 Starting a Dancer project
 
@@ -78,6 +82,10 @@ with a configuration file, a views directory (where your templates and layouts
 will live), an environments directory (where environment-specific settings
 live), a module containing the actual guts of your application, a script to
 start it - or to run your web app via Plack/PSGI - more on that later.
+
+
+
+=head1 DANCE ROUTINES: ROUTES
 
 =head2 Declaring routes
 
@@ -121,6 +129,7 @@ parameters supplied on the query string, within the path itself (with named
 placeholders), and, for HTTTP POST requests, the content of the POST body.
 
 
+
 =head2 Named parameters in route path declarations
 
 As seen above, you can use C<:somename> in a route's path to capture part of the
@@ -133,6 +142,7 @@ use something like:
         my $company_id = params->{companyid};
         # Look up the company and return appropriate page
     };
+
 
 
 =head2 Wildcard path matching and splat
@@ -151,6 +161,7 @@ with C<splat>:
             return "What?";
         }
     };
+
 
 
 =head2 Before filters - processed before a request
@@ -172,6 +183,7 @@ The above declares a before filter which uses C<var> to set a variable which
 will later be available within the route handler, then amends the path of the
 request to C</foo/oversee>; this means that, whatever path was requested, it
 will be treated as though the path requested was C</foo/oversee>.
+
 
 
 =head2 Default route
@@ -215,6 +227,8 @@ Simply enable auto_page in your config:
 Then, if you request C</foo/bar>, Dancer will look in the views dir for
 C</foo/bar.tt>.
 
+
+
 =head2 Why should I use the Ajax plugin
 
 As an Ajax query is just a HTTP query, it's similar to a GET or POST
@@ -256,6 +270,8 @@ and
 Because it's an ajax query, you know you need to return a xml content,
 so the content type of the response is set for you.
 
+
+
 =head2 Using the prefix feature to split your application
 
 For better maintainability, you may want to separate some of your application
@@ -287,6 +303,10 @@ The following routes will be generated for us:
     - get /admin/
     - head /
     - head /admin/
+
+
+
+=head1 MUSCLE MEMORY: STORING DATA
 
 =head2 Handling sessions
 
@@ -327,6 +347,7 @@ Storing data in the session is as easy as:
     session varname => 'value';
 
 
+
 =head3 Retrieving data from the session
 
 Retrieving data from the session is as easy as:
@@ -336,6 +357,7 @@ Retrieving data from the session is as easy as:
 Or, alternatively,
 
     session->{varname}
+
 
 
 =head3 Controlling where sessions are stored
@@ -352,6 +374,8 @@ and easily within your config file, for example:
 
 If the directory you specify does not exist, Dancer will attempt to create it
 for you.
+
+
 
 =head3 Destroying a session
 
@@ -428,11 +452,15 @@ wouldn't store your users passwords in the clear, would you?)) follows:
 
 
 
+=head1 APPEARANCE
+
 =head2 Using templates - views and layouts
 
 Returning plain content is all well and good for examples or trivial apps, but
 soon you'll want to use templates to maintain separation between your code and
 your content.  Dancer makes this easy.
+
+
 
 =head3 Views
 
@@ -478,6 +506,8 @@ The template 'hello.tt' could contain, for example:
     <% IF session.username %>
         <p>You're logged in as <% session.username %>
     <% END %>
+
+
 
 =head3 Layouts
 
@@ -530,6 +560,8 @@ THen in your layout, modify your css inclusion as follows:
 From now on, you can mount your application wherever you want, without
 any further modification of the css inclusion
 
+
+
 =head3 template and unicode
 
 If you use L<Plack> and have some unicode problem with your Dancer application,
@@ -541,6 +573,8 @@ config.yml will look like this:
     engines:
       template_toolkit:
         ENCODING: utf8
+
+
 
 =head3 TT's WRAPPER directive in Dancer (META variables, SETs)
 
@@ -579,6 +613,10 @@ Change the configuration of the template to Template Toolkit:
 
 Done! Everything will work fine out of the box, including variables and META
 variables.
+
+
+
+=head1 SETTING THE STAGE: CONFIGURATION AND LOGGING
 
 =head2 Configuration and environments
 
@@ -623,6 +661,7 @@ And in a production one:
     show_errors: 0
 
 
+
 =head2 Accessing configuration information from your app
 
 A Dancer application can use the 'config' keyword to easily access the settings
@@ -634,6 +673,8 @@ within its config file, for instance:
 
 This makes keeping your application's settings all in one place simple and easy
 - you shouldn't need to worry about implementing all that yourself :)
+
+
 
 =head2 Accessing configuration information from a separate script
 
@@ -703,38 +744,7 @@ like we do above with config->{environment}='production'. Of course, this value
 does not get written in any file; it only lives in memory and your webapp
 doesn't have access to it, but you can use it inside your script.
 
-=head2 Plack middlewares
 
-If you deploy with Plack and use some Plack middlewares, you can enable them
-directly from Dancer's configuration files.
-
-To enable middlewares in Dancer, you just have to set the plack_middlewares
-setting like the following:
-
-    set plack_middlewares => [
-        [ 'SomeMiddleware' => [ qw(some options for somemiddleware) ]],
-    ];
-
-For instance, if you want to enable L<Plack::Middleware::Debug> in your Dancer
-application, all you have to do is to set C<plack_middlewares> like that:
-
-    set plack_middlewares => [
-        [ 'Debug' => [ 'panels' => [ qw(DBITrace Memory Timer) ]]],
-    ];
-
-Of course, you can also put this configuration into your config.yml file, or
-even in your environment configuration files:
-
-    # environments/development.yml
-    ...
-    plack_middlewares:
-      -
-        - Debug          # first element of the array is the name of the middleware
-        - panels         # following elements are the configuration ofthe middleware
-        -
-          - DBITrace
-          - Memory
-          - Timer
 
 =head2 Logging
 
@@ -768,6 +778,10 @@ information (file and line).
 Just call  C<debug>, C<warning> or C<error> with your message:
 
     debug "This is a debug message from my app.";
+
+
+
+=head1 RESTING
 
 =head2 Writing a REST application
 
@@ -829,6 +843,43 @@ The content of the error will be serialized using the appropriate serializer.
 For examples on deploying your Dancer applications (including standalone, behind
 proxy/load-balancing software, and using common web servers including Apache to
 run via CGI/FastCGI etc, see L<Dancer::Deployment>.
+
+
+
+=head1 DANCER ON THE STAGE: DEPLOYMENT
+
+=head2 Plack middlewares
+
+If you deploy with Plack and use some Plack middlewares, you can enable them
+directly from Dancer's configuration files.
+
+To enable middlewares in Dancer, you just have to set the plack_middlewares
+setting like the following:
+
+    set plack_middlewares => [
+        [ 'SomeMiddleware' => [ qw(some options for somemiddleware) ]],
+    ];
+
+For instance, if you want to enable L<Plack::Middleware::Debug> in your Dancer
+application, all you have to do is to set C<plack_middlewares> like that:
+
+    set plack_middlewares => [
+        [ 'Debug' => [ 'panels' => [ qw(DBITrace Memory Timer) ]]],
+    ];
+
+Of course, you can also put this configuration into your config.yml file, or
+even in your environment configuration files:
+
+    # environments/development.yml
+    ...
+    plack_middlewares:
+      -
+        - Debug          # first element of the array is the name of the middleware
+        - panels         # following elements are the configuration ofthe middleware
+        -
+          - DBITrace
+          - Memory
+          - Timer
 
 
 =head1 AUTHORS


### PR DESCRIPTION
This pr does three things, only the first I am serious about. 

1) If a new Dancer looks at http://search.cpan.org/~sukria/Dancer-1.3014/lib/Dancer/Cookbook.pod
the first impression will not as good as it can be. There are almost 30 recipes listed without grouping. I suggest to group them. I don't really care how. Just some chunking and some headlines. 

2)
The headlines I suggest attempt to follow the order we already have for the most part. And they are a little bit playful. Puns more or less in the tradition of Christensen's Cookbook, I think. Dancer lends itself to some metaphor, i find like the wallflowr. 

If you don't like that, change it. I see how it might be confusing. But it could also be fun and Dancer is fun!

3)
There was a pattern to have 3 newlines before =head1 or =head2 and I tried to make that more systematic since it helps when reading pod directly. I might have made some mistakes in this respect since I am still struggling with git/github a lot.
