### PR TITLE
Pr/gitignore - Adding extra stuff to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,6 @@
-Makefile
-.last_cover_stats
-MANIFEST.bak
+# Dancer Specific
 *.old
-*.swp
 *~
-blib
-pm_to_blib
-cover_db
 example/logs
 t/*/logs
 t/*/sessions
@@ -15,3 +9,41 @@ TestApp
 t/sessions/
 tags
 MYMETA.yml
+
+
+# From: https://github.com/github/gitignore/blob/master/Global/Linux.gitignore
+.*
+!.gitignore
+*~
+*.sw[a-p]
+.directory
+
+
+# From: https://github.com/github/gitignore/blob/master/Global/Windows.gitignore
+Thumbs.db
+Desktop.ini
+
+
+# From https://github.com/github/gitignore/blob/master/Global/OSX.gitignore
+.DS_Store
+Icon?
+._*
+.Spotlight-V100
+.Trashes
+
+
+# From https://github.com/github/gitignore/blob/master/Perl.gitignore
+blib/
+_build/
+cover_db/
+inc/
+Build
+Build.bat
+.last_cover_stats
+Makefile
+Makefile.old
+MANIFEST.bak
+META.yml
+MYMETA.yml
+nytprof.out
+pm_to_blib


### PR DESCRIPTION
Specifically, I want the .DS_Store file that Mac OS X shoves everywhere in the gitignore.

While I was at it, thought I'd add a few other files from the "official" gitignores provided by github.

Everything that was in the old gitignore is covered in this new one.
