### PR TITLE
Support cookie expire times like +2h

### DIFF
--- a/t/09_cookies/02_cookie_object.t
+++ b/t/09_cookies/02_cookie_object.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 13;
+use Test::More tests => 5;
 use Dancer::Cookie;
 
 my $c = Dancer::Cookie->new(
@@ -13,29 +13,6 @@ is(ref($c), 'Dancer::Cookie',
 
 is($c->to_header, 'dancer.slot=42; path=/; HttpOnly',
     "simple cookie header looks good");
-
-my %tests = (
-    1288817656 => "Wed, 03-Nov-2010 20:54:16 GMT",
-    1288731256 => "Tue, 02-Nov-2010 20:54:16 GMT",
-    1288644856 => "Mon, 01-Nov-2010 20:54:16 GMT",
-    1288558456 => "Sun, 31-Oct-2010 20:54:16 GMT",
-    1288472056 => "Sat, 30-Oct-2010 20:54:16 GMT",
-    1288385656 => "Fri, 29-Oct-2010 20:54:16 GMT",
-    1288299256 => "Thu, 28-Oct-2010 20:54:16 GMT",
-    1288212856 => "Wed, 27-Oct-2010 20:54:16 GMT",
-);
-
-while(my ($time, $expected) = each %tests) {
-    $c = Dancer::Cookie->new(
-        name  => 'dancer.slot',
-        value => 42,
-        expires => $time,
-    );
-
-    is($c->to_header, 
-        "dancer.slot=42; path=/; expires=$expected; HttpOnly",
-        "header with expires looks good ($time)");
-}
 
 $c = Dancer::Cookie->new(
     name => 'dancer.slot',

--- a/t/09_cookies/06_expires.t
+++ b/t/09_cookies/06_expires.t
@@ -1,0 +1,59 @@
+use strict;
+use warnings;
+use Test::More;
+
+BEGIN {
+    # Freeze time at Tue, 15-Jun-2010 00:00:00 GMT
+    *CORE::GLOBAL::time = sub { return 1276560000 }
+}
+
+use Dancer::Cookie;
+
+my $min  = 60;
+my $hour = 60 * $min;
+my $day  = 24 * $hour;
+my $week = 7 * $day;
+my $mon  = 30 * $day;
+my $year = 365 * $day;
+
+note "expiration times"; {
+    my %times = (
+        "+2h"                       => "Tue, 15-Jun-2010 02:00:00 GMT",
+        "-2h"                       => "Mon, 14-Jun-2010 22:00:00 GMT",
+        "1 hour"                    => "Tue, 15-Jun-2010 01:00:00 GMT",
+        "3 weeks 4 days 2 hours 99 min 0 secs" => "Sat, 10-Jul-2010 03:39:00 GMT",
+        "2 months"                  => "Sat, 14-Aug-2010 00:00:00 GMT",
+        "12 years"                  => "Sun, 12-Jun-2022 00:00:00 GMT",
+
+        1288817656 => "Wed, 03-Nov-2010 20:54:16 GMT",
+        1288731256 => "Tue, 02-Nov-2010 20:54:16 GMT",
+        1288644856 => "Mon, 01-Nov-2010 20:54:16 GMT",
+        1288558456 => "Sun, 31-Oct-2010 20:54:16 GMT",
+        1288472056 => "Sat, 30-Oct-2010 20:54:16 GMT",
+        1288385656 => "Fri, 29-Oct-2010 20:54:16 GMT",
+        1288299256 => "Thu, 28-Oct-2010 20:54:16 GMT",
+        1288212856 => "Wed, 27-Oct-2010 20:54:16 GMT",
+
+        # Anything not understood is passed through
+        "basset hounds got long ears" => "basset hounds got long ears",
+    );
+
+    for my $exp (keys %times) {
+        my $want = $times{$exp};
+        note $want;
+
+        my $cookie = Dancer::Cookie->new(
+            name        => "shut.up.and.dance",
+            value       => "FMV",
+            expires     => $exp
+        );
+
+        is($cookie->to_header, 
+           "shut.up.and.dance=FMV; path=/; expires=$want; HttpOnly",
+           "header with expires");
+
+        is $cookie->expires, $want, "expires";
+    }
+}
+
+done_testing;


### PR DESCRIPTION
Implements #392

I decided to go with Time::Duration::Parse's code because it is more complete, easier to follow and we can blame miyagawa if it breaks. :-P
