### PR TITLE
Honor changing session_name

### DIFF
--- a/lib/Dancer/Session/Abstract.pm
+++ b/lib/Dancer/Session/Abstract.pm
@@ -53,10 +53,6 @@ sub init {
     $self->id(build_id());
 }
 
-# session name can be set in configuration file:
-# setting session_name => 'mydancer.session';
-my $SESSION_NAME = session_name();
-
 # this method can be overwrite in any Dancer::Session::* module
 sub session_name {
     setting('session_name') || 'dancer.session';
@@ -83,14 +79,17 @@ sub build_id {
 }
 
 sub read_session_id {
-    my $c = Dancer::Cookies->cookies->{$SESSION_NAME};
+    my $name = session_name();
+    my $c = Dancer::Cookies->cookies->{$name};
     return (defined $c) ? $c->value : undef;
 }
 
 sub write_session_id {
     my ($class, $id) = @_;
+
+    my $name = session_name();
     my %cookie = (
-        name   => $SESSION_NAME,
+        name   => $name,
         value  => $id,
         secure => setting('session_secure')
     );
@@ -100,7 +99,7 @@ sub write_session_id {
     }
 
     my $c = Dancer::Cookie->new(%cookie);
-    Dancer::Cookies->set_cookie_object($SESSION_NAME => $c);
+    Dancer::Cookies->set_cookie_object($name => $c);
 }
 
 1;

--- a/t/08_session/12_session_name.t
+++ b/t/08_session/12_session_name.t
@@ -1,0 +1,27 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 7;
+use Dancer ':syntax', ':tests';
+
+set session => "simple";
+
+note "changing session name"; {
+    my $orig_name = setting("session_name");
+    session foo => "bar";
+    is session("foo"), "bar";
+
+    set session_name => "something.else";
+    is setting("session_name"), "something.else", "session_name changed";
+    isnt session("foo"), "bar",                   "other session's values not seen";
+
+    session up => "down";
+    is session("up"), "down",                     "storing our values";
+
+    set session_name => $orig_name;
+    is setting("session_name"), $orig_name,       "set back to the original name";
+    isnt session("up"), "down",                   "other session's values not seen";
+    is session("foo"), "bar",                     "original value restored";
+}


### PR DESCRIPTION
Dancer::Session::Abstract would check the session_name once when loading and never again.  This meant it would ignore if the `session_name` changed after it loaded.

This both avoids subtle bugs where the user sets the session_name after Dancer::Session::Abstract is loaded as well as allowing multiple sessions to be maintained for a single user in one process (the feature I need).
