### PR TITLE
Fix plack_middlewares example in the cookbook

### DIFF
--- a/lib/Dancer/Cookbook.pod
+++ b/lib/Dancer/Cookbook.pod
@@ -864,7 +864,7 @@ For instance, if you want to enable L<Plack::Middleware::Debug> in your Dancer
 application, all you have to do is to set C<plack_middlewares> like that:
 
     set plack_middlewares => [
-        [ 'Debug' => [ 'panels' => [ qw(DBITrace Memory Timer) ]]],
+        [ 'Debug' => [ 'panels' => qw(DBITrace Memory Timer) ]],
     ];
 
 Of course, you can also put this configuration into your config.yml file, or


### PR DESCRIPTION
The example has one too many sets of array refs.  Plack turns on debug panels but then ignores the options.
