### PR TITLE
POD addition to Dancer::Plugin

### DIFF
--- a/lib/Dancer/Plugin.pm
+++ b/lib/Dancer/Plugin.pm
@@ -157,7 +157,11 @@ Configuration for plugin should be structured like this in the config.yaml of th
     plugin_name:
       key: value
 
-If plugin_setting is called inside a plugin, the appropriate configuration will be returned. The plugin_name should be the name of the package, or, if the plugin name is under the Dancer::Plugin:: namespace, the end part of the plugin name.
+If plugin_setting is called inside a plugin, the appropriate configuration will be returned. The plugin_name should be the name of the package, or, if the plugin name is under the Dancer::Plugin:: namespace, the remaining part of the plugin name. Enclose the remaining part in quotes if it contains ::, e.g. for Dancer::Plugin::Foo::Bar, use:
+
+  plugins:
+    "Foo::Bar":
+      key: value
 
 =back
 


### PR DESCRIPTION
I'm pretty much a newbie with Dancer and started to write a plugin "Dancer::Plugin::Wiki::Toolkit". My application crashed because I didn't know that I need to enclose "Wiki::Toolkit" in quotes in the configuration.
The crash message wasn't helpful either.

Regards
              Racke
