### PR TITLE
Pr/critical warnings - Solve issue #418

### DIFF
--- a/examples/dancr/dancr.pl
+++ b/examples/dancr/dancr.pl
@@ -11,7 +11,7 @@ set 'logger' => 'console';
 set 'log' => 'debug';
 set 'show_errors' => 1;
 set 'access_log' => 1;
-set 'warnings' => 1;
+set 'critical_warnings' => 1;
 set 'username' => 'admin';
 set 'password' => 'password';
 

--- a/lib/Dancer/Config.pm
+++ b/lib/Dancer/Config.pm
@@ -199,17 +199,18 @@ sub load_settings_from_yaml {
 }
 
 sub load_default_settings {
-    $SETTINGS->{server}       ||= $ENV{DANCER_SERVER}       || '0.0.0.0';
-    $SETTINGS->{port}         ||= $ENV{DANCER_PORT}         || '3000';
-    $SETTINGS->{content_type} ||= $ENV{DANCER_CONTENT_TYPE} || 'text/html';
-    $SETTINGS->{charset}      ||= $ENV{DANCER_CHARSET}      || '';
-    $SETTINGS->{access_log}   ||= $ENV{DANCER_ACCESS_LOG}   || 1;
-    $SETTINGS->{daemon}       ||= $ENV{DANCER_DAEMON}       || 0;
-    $SETTINGS->{apphandler}   ||= $ENV{DANCER_APPHANDLER}   || 'Standalone';
-    $SETTINGS->{warnings}     ||= $ENV{DANCER_WARNINGS}     || 0;
-    $SETTINGS->{auto_reload}  ||= $ENV{DANCER_AUTO_RELOAD}  || 0;
-    $SETTINGS->{traces}       ||= $ENV{DANCER_TRACES}       || 0;
-    $SETTINGS->{logger}       ||= $ENV{DANCER_LOGGER}       || 'file';
+    $SETTINGS->{server}        ||= $ENV{DANCER_SERVER}       || '0.0.0.0';
+    $SETTINGS->{port}          ||= $ENV{DANCER_PORT}         || '3000';
+    $SETTINGS->{content_type}  ||= $ENV{DANCER_CONTENT_TYPE} || 'text/html';
+    $SETTINGS->{charset}       ||= $ENV{DANCER_CHARSET}      || '';
+    $SETTINGS->{access_log}    ||= $ENV{DANCER_ACCESS_LOG}   || 1;
+    $SETTINGS->{daemon}        ||= $ENV{DANCER_DAEMON}       || 0;
+    $SETTINGS->{apphandler}    ||= $ENV{DANCER_APPHANDLER}   || 'Standalone';
+    # later we might deprecate "warnings"
+    $SETTINGS->{critical_warnings} ||= $SETTINGS->{warnings} || $ENV{DANCER_WARNINGS}     || 0;
+    $SETTINGS->{auto_reload}   ||= $ENV{DANCER_AUTO_RELOAD}  || 0;
+    $SETTINGS->{traces}        ||= $ENV{DANCER_TRACES}       || 0;
+    $SETTINGS->{logger}        ||= $ENV{DANCER_LOGGER}       || 'file';
     $SETTINGS->{environment} ||=
          $ENV{DANCER_ENVIRONMENT}
       || $ENV{PLACK_ENV}

--- a/lib/Dancer/Introduction.pod
+++ b/lib/Dancer/Introduction.pod
@@ -221,7 +221,7 @@ This is a choice left to the end-user and can be set with the
 B<show_errors> setting.
 
 Note that you can also choose to consider all warnings in your route handlers
-as errors when the setting B<warnings> is set to 1.
+as errors when the setting B<critical_warnings> is set to 1.
 
 =head1 FILTERS
 

--- a/lib/Dancer/Route.pm
+++ b/lib/Dancer/Route.pm
@@ -218,7 +218,7 @@ sub find_next_matching_route {
 sub execute {
     my ($self) = @_;
 
-    if (Dancer::Config::setting('warnings')) {
+    if (Dancer::Config::setting('critical_warnings')) {
         my $warning;
         local $SIG{__WARN__} = sub { $warning = $_[0] };
         my $content = $self->code->();

--- a/lib/Dancer/Tutorial.pod
+++ b/lib/Dancer/Tutorial.pod
@@ -236,7 +236,7 @@ more options than just the session engine we want to set.
   set 'log' => 'debug';
   set 'show_errors' => 1;
   set 'access_log' => 1;
-  set 'warnings' => 1;
+  set 'critical_warnings' => 1;
 
 Hopefully these are fairly self-explanatory. We want the Simple session engine,
 the Template Toolkit template engine, logging enabled (at the 'debug' level
@@ -445,7 +445,7 @@ Here's the complete dancr.pl script from start to finish.
  set 'log' => 'debug';
  set 'show_errors' => 1;
  set 'access_log' => 1;
- set 'warnings' => 1;
+ set 'critical_warnings' => 1;
  set 'username' => 'admin';
  set 'password' => 'password';
  

--- a/script/dancer
+++ b/script/dancer
@@ -873,7 +873,7 @@ logger: \"console\"
 log: \"core\"
 
 # should Dancer consider warnings as critical errors?
-warnings: 1
+critical_warnings: 1
 
 # should Dancer show a stacktrace when an error is caught?
 show_errors: 1
@@ -898,7 +898,7 @@ log: "warning"
 logger: "file"
 
 # don\'t consider warnings critical
-warnings: 0
+critical_warnings: 0
 
 # hide errors 
 show_errors: 0

--- a/t/03_route_handler/07_compilation_warning.t
+++ b/t/03_route_handler/07_compilation_warning.t
@@ -14,7 +14,7 @@ Dancer::Logger->init('File');
 # perl <= 5.8.x won't catch the warning
 plan skip_all => 'Need perl >= 5.10' if $] < 5.010;
 
-set warnings => 1;
+set critical_warnings => 1;
 set show_errors => 1;
 
 get '/warning' => sub {


### PR DESCRIPTION
As described on issue 418, the warnings key is not clear on environment configuration files. I propose "critical_warnings", that make more sense (I think).

ATM the old "warnings" is still accepted. We might need to deprecate it later, someday.
