### PR TITLE
recognize absolute redirects

### DIFF
--- a/lib/Dancer.pm
+++ b/lib/Dancer.pm
@@ -282,7 +282,7 @@ sub _mime_type {
 
 sub _redirect {
     my ($destination, $status) = @_;
-    if ($destination !~ m!^(\w+://)?/!) {
+    if ($destination !~ m!^(\w+:/)?/!) {
         # no absolute uri here, build one, RFC 2616 forces us to do so
         my $request = Dancer::SharedData->request;
         $destination = $request->uri_for($destination, {}, 1);

--- a/t/redirect.t
+++ b/t/redirect.t
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use Dancer::Test;
+
+use Dancer ':syntax';
+
+plan tests => 3;
+
+get '/absolute_with_host' => sub { redirect "http://foo.com/somewhere"; };
+get '/absolute' => sub { redirect "/absolute"; };
+get '/relative' => sub { redirect "somewhere/else"; };
+
+my $res = dancer_response GET => '/absolute_with_host';
+is $res->header('Location') => 'http://foo.com/somewhere';
+
+$res = dancer_response GET => '/absolute';
+is $res->header('Location') => '/absolute';
+
+$res = dancer_response GET => '/relative';
+is $res->header('Location') => 'http://localhost/somewhere/else';


### PR DESCRIPTION
I might be wrong, but I think _redirect() had two issues:
1. the condition should be negated, as the 'if' is to deal with uris that
   aren't absolute.
2. the regex should have \w+, as we want to make 'http', 'https', etc.
