### PR TITLE
Added default_mime_type docs

### DIFF
--- a/lib/Dancer/Config.pm
+++ b/lib/Dancer/Config.pm
@@ -394,6 +394,14 @@ use them.
 
 See L<Dancer::Session> for supported engines and their respective configuration.
 
+=head2 default_mime_type (string)
+
+Dancer's L<Dancer::MIME> module uses C<application/data> as a default
+mime type. This setting lets the user change it. For example, if you
+have a lot of files being served in the B<public> folder that do not
+have an extension, and are text files, set the C<default_mim_type> to
+C<text/plain>.
+
 =head1 AUTHOR
 
 This module has been written by Alexis Sukrieh <sukria@cpan.org> and others,


### PR DESCRIPTION
When documenting the "error _template" noticed I forgot to document the "default_mime_type" in a proper place.

Cheers.

Yay, and a proper PR, finally!
