### PR TITLE
introduce the "megasplat"

### DIFF
--- a/lib/Dancer/Route.pm
+++ b/lib/Dancer/Route.pm
@@ -76,8 +76,17 @@ sub match {
           . $self->{_compiled_regexp}
           . "/");
 
-    my @values = map { m#/# ? [ split '/' => $_ ] : $_ } 
-                     $path =~ $self->{_compiled_regexp};
+    my @values = $path =~ $self->{_compiled_regexp};
+
+    # the regex comments are how we know if we captured
+    # a splat or a megasplat
+    if( my @splat_or_megasplat 
+            = $self->{_compiled_regexp} =~ /\(\?#((?:mega)?splat)\)/g ) {
+        for ( @values ) {
+            $_ = [ split '/' => $_ ] if ( shift @splat_or_megasplat ) =~ /megasplat/;
+        }
+    }
+
     Dancer::Logger::core("  --> got ".
         map { defined $_ ? $_ : 'undef' } @values) 
         if @values;
@@ -313,13 +322,10 @@ sub _build_regexp_from_string {
     # parse megasplat
     # we use {0,} instead of '*' not to fall in the splat rule
     # same logic for [^\n] instead of '.'
-    $capture = 1 if $pattern =~ s!\Q**\E!([^\n]+)!g;
+    $capture = 1 if $pattern =~ s!\Q**\E!(?#megasplat)([^\n]+)!g;
 
     # parse wildcards
-    if ($pattern =~ /\*/) {
-        $pattern =~ s/\*/\(\[\^\/\]\+\)/g;
-        $capture = 1;
-    }
+    $capture = 1 if $pattern =~ s!\*!(?#splat)([^/]+)!g;
 
     # escape dots
     $pattern =~ s/\./\\\./g if $pattern =~ /\./;

--- a/t/03_route_handler/04_wildcards_megasplat.t
+++ b/t/03_route_handler/04_wildcards_megasplat.t
@@ -3,7 +3,7 @@ use Test::More;
 
 use Dancer::Test;
 
-plan tests => 3;
+plan tests => 4;
 
 get '/foo/**'   => sub { show_splat() };
 response_content_is [ GET => '/foo/a/b/c' ] => '(a,b,c)';
@@ -13,6 +13,7 @@ response_content_is [ GET => '/bar/a/b/c' ] => 'a:(b,c)';
 
 get '/alpha/**/gamma' => sub { show_splat() };
 response_content_is [ GET => '/alpha/beta/delta/gamma' ] => '(beta,delta)';
+response_content_is [ GET => '/alpha/beta/gamma' ] => '(beta)';
 
 sub show_splat {
     return join ':', map { ref $_ ? "(" . join( ',', @$_ ) . ")": $_ } splat;


### PR DESCRIPTION
this is actually more of a RFC than  a pull request.  Would you guys be partial to the introduction of a "megasplat" glob (*_), that would act like the regular '_', but slurp slashes as well?

I can see two direct uses for it:

a) if we can a variable number of elements at the end of the path:

```
# matches /entry/foo/tags/one/two/three
get '/entry/*/tags/**' => sub {
    my ( $entry_id, $tags ) = splat;
    my @tags = split '/' => $tags;

    # etc...
};
```

b) to make kinda-chained actions:

```
get '/team/*/**' => sub {
    my ( $team ) = splat;
    var team => $team;
    pass;
};

prefix '/team/*';

get '/player/*' => sub {
    my( $player ) = splat;

    # etc...
};

get '/score' => sub {
    return score_for( vars->{team} );
};
```

If you like the idea, I'll flesh out the documentation a little bit, and will try to beef up the related test cases. If not, oh well, I had to try, if only for the name of the operator. :-)
