### PR TITLE
Redirects should be issuing absolute URIs in the Location header

### DIFF
--- a/lib/Dancer.pm
+++ b/lib/Dancer.pm
@@ -277,10 +277,15 @@ sub _init_script_dir {
     $res or croak "unable to set libdir : $error";
 }
 
+# Scheme grammar as defined in RFC 2396
+#  scheme = alpha *( alpha | digit | "+" | "-" | "." )
+my $scheme_re = qr{ [a-z][a-z0-9\+\-\.]* }ix;
 sub _redirect {
     my ($destination, $status) = @_;
-    if ($destination !~ m!^(\w+:/)?/!) {
-        # no absolute uri here, build one, RFC 2616 forces us to do so
+
+    # RFC 2616 requires an absolute URI with a scheme,
+    # turn the URI into that if it needs it
+    if ($destination !~ m{^ $scheme_re : }x) {
         my $request = Dancer::SharedData->request;
         $destination = $request->uri_for($destination, {}, 1);
     }

--- a/t/03_route_handler/02_before_filter.t
+++ b/t/03_route_handler/02_before_filter.t
@@ -66,7 +66,7 @@ response_content_is $request, 'index',
     "which is the result of a redirection to /";
 
 response_headers_include [GET => '/redirect_from'] => [
-    'Location' => '/redirect_to',
+    'Location' => 'http://localhost/redirect_to',
     'Content-Type' => 'text/xhtml',
 ];
 

--- a/t/03_route_handler/11_redirect.t
+++ b/t/03_route_handler/11_redirect.t
@@ -26,7 +26,7 @@ response_content_is [GET => '/'], "home";
 get '/redirect' => sub { header 'X-Foo' => 'foo'; redirect '/'; };
 
 my $expected_headers = [
-    'Location' => '/',
+    'Location' => 'http://localhost/',
     'Content-Type' => 'text/html',
     'X-Foo' => 'foo',
 ];
@@ -34,7 +34,7 @@ response_headers_include [GET => '/redirect'] => $expected_headers;
 
 get '/redirect_querystring' => sub { redirect '/login?failed=1' };
 $expected_headers = [
-    'Location' => '/login?failed=1',
+    'Location' => 'http://localhost/login?failed=1',
     'Content-Type' => 'text/html',
 ];
 response_headers_include [GET => '/redirect_querystring'] => $expected_headers;

--- a/t/03_route_handler/11_redirect_absolute.t
+++ b/t/03_route_handler/11_redirect_absolute.t
@@ -16,7 +16,7 @@ my $res = dancer_response GET => '/absolute_with_host';
 is $res->header('Location') => 'http://foo.com/somewhere';
 
 $res = dancer_response GET => '/absolute';
-is $res->header('Location') => '/absolute';
+is $res->header('Location') => 'http://localhost/absolute';
 
 $res = dancer_response GET => '/relative';
 is $res->header('Location') => 'http://localhost/somewhere/else';

--- a/t/03_route_handler/29_redirect_immediately.t
+++ b/t/03_route_handler/29_redirect_immediately.t
@@ -24,6 +24,6 @@ response_exists [ GET => '/' ];
 response_content_is [ GET => '/' ], "im home";
 
 response_exists [ GET => '/false' ];
-response_headers_include [GET => '/false'] => ['Location'=>'/'];
+response_headers_include [GET => '/false'] => ['Location'=>'http://localhost/'];
 
 is $pass, 0;

--- a/t/03_route_handler/30_bug_gh190.t
+++ b/t/03_route_handler/30_bug_gh190.t
@@ -12,6 +12,6 @@ ok( before( sub { redirect '/somewhere' } ) );
 ok( get( '/', sub { $i++; 'Hello' } ) );
 
 route_exists                [ GET => '/' ];
-response_headers_include    [ GET => '/' ] => [ Location => '/somewhere' ];
+response_headers_include    [ GET => '/' ] => [ Location => 'http://localhost/somewhere' ];
 response_content_is         [ GET => '/' ], '';
 is $i, 0;


### PR DESCRIPTION
The code and tests treat "Location: /foo" as ok, but I believe it is a misinterpretation of what "absolute URI" means.

RFC 2616 section 14.30 on the Location header states:

```
The field value consists of a single absolute URI.

   Location       = "Location" ":" absoluteURI

An example is:

   Location: http://www.w3.org/pub/WWW/People.html
```

With absoluteURI defined in RFC2396 as

```
  absoluteURI   = scheme ":" ( hier_part | opaque_part )
```

The logic to turn schemless URIs into schemed ones appears to have been inverted in 7ba2b7879a02b3050d044ceb5f5c20129e34158d.  Recent changes tinkered with it some more, but it's been broken for a while.

This patches redirect() to always turn relative (ie. schemeless) URIs into absolute (ie. schemed) ones.
