### PR TITLE
remote_host only available with DNS lookup

### DIFF
--- a/lib/Dancer/Request.pm
+++ b/lib/Dancer/Request.pm
@@ -564,7 +564,8 @@ Return the IP address of the client.
 
 =head2 remote_host()
 
-Return the remote host of the client.
+Return the remote host of the client. This only works with web servers configured
+to do a reverse DNS lookup on the client's IP address.
 
 =head2 protocol()
 


### PR DESCRIPTION
See http://httpd.apache.org/docs/current/mod/core.html#hostnamelookups for reference.
