### PR TITLE
Remove deprecated r function from list of exports.

### DIFF
--- a/lib/Dancer.pm
+++ b/lib/Dancer.pm
@@ -68,7 +68,6 @@ our @EXPORT    = qw(
   post
   prefix
   put
-  r
   redirect
   render_with_layout
   request


### PR DESCRIPTION
Function itself was removed but is still present in @EXPORT.
