### PR TITLE
Check forward, and some reordering

### DIFF
--- a/lib/Dancer.pm
+++ b/lib/Dancer.pm
@@ -53,7 +53,6 @@ our @EXPORT    = qw(
   get
   halt
   header
-  push_header
   headers
   layout
   load
@@ -67,6 +66,7 @@ our @EXPORT    = qw(
   path
   post
   prefix
+  push_header
   put
   redirect
   render_with_layout

--- a/t/00_base/003_syntax.t
+++ b/t/00_base/003_syntax.t
@@ -14,6 +14,7 @@ my @keywords = qw(
     dirname
     error
     false
+    forward
     from_dumper
     from_json
     from_yaml
@@ -33,6 +34,7 @@ my @keywords = qw(
     path
     post
     prefix
+    push_header
     put
     redirect
     request


### PR DESCRIPTION
forward was missing from t/00_base/003_syntax.t
Also, reordered push_header.
and of course, did not add the methods that are being deprecated.
