### PR TITLE
use logger instead of STDERR

### DIFF
--- a/lib/Dancer/Handler/Debug.pm
+++ b/lib/Dancer/Handler/Debug.pm
@@ -9,6 +9,7 @@ use base 'Dancer::Object', 'Dancer::Handler', 'HTTP::Server::Simple::PSGI';
 
 use Dancer::Config 'setting';
 use Dancer::SharedData;
+use Dancer::Logger;
 
 sub run {
     my ($self, $req) = @_;
@@ -54,8 +55,8 @@ sub run {
 
 sub start {
     my ($self, $req) = @_;
-    print STDERR ">> Dancer dummy debug server\n" if setting('startup_info');
-    
+    Dancer::Logger::core ">> Dancer dummy debug server\n" if setting('startup_info');
+
     my $dancer = Dancer::Handler::Debug->new();
     my $psgi = sub {
         my $env = shift;

--- a/lib/Dancer/Handler/Standalone.pm
+++ b/lib/Dancer/Handler/Standalone.pm
@@ -6,6 +6,7 @@ use warnings;
 use HTTP::Server::Simple::PSGI;
 use base 'Dancer::Handler', 'HTTP::Server::Simple::PSGI';
 
+use Dancer::Logger;
 use Dancer::HTTP;
 use Dancer::GetOpt;
 use Dancer::Config 'setting';
@@ -28,16 +29,16 @@ sub start {
 
     if (setting('daemon')) {
         my $pid = $dancer->background();
-        print STDERR
+        Dancer::Logger::core
             ">> Dancer $Dancer::VERSION server $pid listening"
-            . "on http://$ipaddr:$port\n"
+              . "on http://$ipaddr:$port\n"
                 if setting('startup_info');
         return $pid;
     }
     else {
-        print STDERR ">> Dancer $Dancer::VERSION server $$ listening"
+        Dancer::Logger::core ">> Dancer $Dancer::VERSION server $$ listening"
             ." on http://$ipaddr:$port\n"
-                if setting('startup_info');
+              if setting('startup_info');
         $dancer->run();
     }
 }


### PR DESCRIPTION
Hopefully this fixes Schwern issue #389. use logger instead of print STDERR.

Also, there is a lot of modules using carp and croak. Should I prepare a pull request (or a set of smaller ones, probably) to remove them?

How should croak be implemented in logger? Dancer::Logger::error(... ) will die?
