### PR TITLE
Allow setting default value in Dancer::Object and Dancer::Object::Singlet

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,8 @@
       (Alberto Simões)
     * Session engine can be told to set cookies without HttpOnly attribute using
     * new session_is_http_only setting. (Alberto Simões, requested by JT Smith)
+    * Allow setting attribute default value in Dancer::Object and
+      Dancer::Object::Singleton (AJGB)
 
     [ DOCUMENTATION ]
     * Major rewrite/reorganization on Dancer::Config documentation

--- a/lib/Dancer/Object/Singleton.pm
+++ b/lib/Dancer/Object/Singleton.pm
@@ -43,13 +43,14 @@ sub instance {
 # accessor code for singleton objects
 # (overloaded from Dancer::Object)
 sub _setter_code {
-    my ($class, $attr) = @_;
+    my ($class, $attr, $default) = @_;
     sub {
         my ($class_or_instance, $value) = @_;
         my $instance = ref $class_or_instance ?
           $class_or_instance : $class_or_instance->instance;
         if (@_ == 1) {
-            return $instance->{$attr};
+            return exists $instance->{$attr} ?
+                $instance->{$attr} : $default;
         }
         else {
             return $instance->{$attr} = $value;
@@ -73,7 +74,12 @@ Dancer::Object::Singleton - Singleton base class for Dancer
     use warnings;
     use base 'Dancer::Object::Singleton';
 
+    # name attributes
     __PACKAGE__->attributes( qw/name value this that/ );
+
+    # or create attribute with default value
+    __PACKAGE__->attribute( foo => 'bar' );
+
 
     sub init {
         my ($class, $instance) = @_;
@@ -109,7 +115,13 @@ you don't want to. init receives the instance as argument.
 
 Get the attributes of the specific class.
 
-=head2 attributes
+=head2 attribute( $name, $default )
+
+Generates attribute with default value for whatever object is extending
+Dancer::Object and saves them in an internal hashref so they can be later
+fetched using C<get_attributes>.
+
+=head2 attributes( @names )
 
 Generates attributes for whatever object is extending Dancer::Object and saves
 them in an internal hashref so they can be later fetched using

--- a/t/00_base/06_dancer_object.t
+++ b/t/00_base/06_dancer_object.t
@@ -8,7 +8,7 @@ use Dancer::ModuleLoader;
 plan skip_all => "the Clone module is needed for this test"
     unless Dancer::ModuleLoader->load('Clone');
 
-plan tests => 19;
+plan tests => 25;
 
 use Dancer::Object;
 
@@ -16,13 +16,14 @@ use Dancer::Object;
     package Person;
     use base 'Dancer::Object';
     __PACKAGE__->attributes('name', 'age', 'sex');
+    __PACKAGE__->attribute( lang => 'perl' );
 }
 
 my $p = Person->new;
 ok $p->init, 'init works';
 
 isa_ok $p, 'Person';
-can_ok $p, qw(new init name age sex);
+can_ok $p, qw(new init name age sex lang);
 
 ok $p->name('john'), 'setting name';
 ok $p->age(10), 'setting age';
@@ -31,29 +32,36 @@ ok $p->sex('male'), 'setting sex';
 is $p->name, 'john', 'getting name';
 is $p->age, 10, 'getting age';
 is $p->sex, 'male', 'getting sex';
+is $p->lang, 'perl', 'getting lang default';
 
 my $p2 = $p->clone;
 isnt $p, $p2, "clone is not the same object";
 is $p->age, $p2->age, "clone values are OK";
+is $p->lang, $p2->lang, "clone values are still OK";
 
 my $attrs = Person->get_attributes();
-is_deeply $attrs, ['name', 'age', 'sex'], "attributes are ok";
+is_deeply $attrs, ['name', 'age', 'sex', 'lang'], "attributes are ok";
 
 {
     package Person::Child;
     use base 'Person';
     __PACKAGE__->attributes('parent');
+    __PACKAGE__->attribute( toy => 'teddy' );
 }
 
 my $child = Person::Child->new();
 ok $child->parent($p), 'setting parent';
 ok $child->name('bob'), 'setting child name';
 ok $child->age(5), 'setting child age';
+ok $child->lang('perl6'), 'setting child lang';
 
 is $child->age, 5, 'age is ok';
 is $child->parent->sex, 'male', 'age is ok';
+is $child->toy, 'teddy', 'toy is ok';
+is $child->lang, 'perl6', 'lang is ok';
+is $child->parent->lang, 'perl', 'parent\'s lang is ok';
 my $child_attrs = Person::Child->get_attributes();
-is_deeply $child_attrs, ['parent', 'name', 'age', 'sex'], "attributes are ok";
+is_deeply $child_attrs, ['parent', 'toy', 'name', 'age', 'sex', 'lang'], "attributes are ok";
 
 {
     package Person::Child::Blond;
@@ -63,4 +71,4 @@ is_deeply $child_attrs, ['parent', 'name', 'age', 'sex'], "attributes are ok";
 
 my $blond_child = Person::Child::Blond->new();
 my $blond_child_attrs = Person::Child::Blond->get_attributes();
-is_deeply $blond_child_attrs, ['hair_length', 'parent', 'name', 'age', 'sex'], "attributes are ok";
+is_deeply $blond_child_attrs, ['hair_length', 'parent', 'toy', 'name', 'age', 'sex', 'lang'], "attributes are ok";

--- a/t/00_base/13_dancer_singleton.t
+++ b/t/00_base/13_dancer_singleton.t
@@ -3,7 +3,7 @@ use warnings;
 
 use Test::More import => ['!pass'];
 
-plan tests => 10;
+plan tests => 12;
 
 my $test_counter = 0;
 
@@ -11,6 +11,7 @@ my $test_counter = 0;
     package MySingleton;
     use base qw(Dancer::Object::Singleton);
 
+    __PACKAGE__->attribute( bar => 'baz' );
     __PACKAGE__->attributes( qw/foo/ );
 
     sub init {
@@ -34,6 +35,9 @@ is $test_counter, 1, 'counter incremented';
 is $instance->foo, 'bar', 'attribute is set';
 $instance->foo('baz');
 is $instance->foo, 'baz', 'attribute changed';
+is $instance->bar, 'baz', 'attribute has default';
+$instance->bar('foo');
+is $instance->bar, 'foo', 'attribute changed';
 
 my $instance2 =  MySingleton->instance();
 ok $instance2, 'instance retrieved';


### PR DESCRIPTION
Hi,

This allows to create attributes with defined default values, as init() in parent class using attributes_defaults() can be overridden by sub-class.

Cheers,
Alex
