### PR TITLE
tests response_exists and response_doesnt_exist always pass/fail

### DIFF
--- a/lib/Dancer/Test.pm
+++ b/lib/Dancer/Test.pm
@@ -124,20 +124,26 @@ sub response_exists {
     my ($req, $test_name) = @_;
 
     $test_name ||= "a response is found for " . _req_label($req);
-    my $tb = Test::Builder->new;
 
     my $response = _req_to_response( $req );
-    return $tb->ok(defined($response), $test_name);
+
+    # goto used so that the test reports
+    # the correct test line
+    @_ = ( $response, 404, $test_name );
+    goto &response_status_isnt;
 }
 
 sub response_doesnt_exist {
     my ($req, $test_name) = @_;
 
     $test_name ||= "no response found for " . _req_label($req);
-    my $tb = Test::Builder->new;
 
     my $response = _req_to_response($req);
-    return $tb->ok(!defined($response), $test_name);
+
+    # goto used so that the test reports
+    # the correct test line
+    @_ = ( $response, 404, $test_name );
+    goto &response_status_is;
 }
 
 sub response_status_is {

--- a/t/00_base/dancer_test_functions.t
+++ b/t/00_base/dancer_test_functions.t
@@ -3,7 +3,7 @@ use warnings;
 
 use Test::More;
 
-plan tests => 24;
+plan tests => 26;
 
 use Dancer qw/ :syntax :tests /;
 use Dancer::Test;
@@ -20,6 +20,10 @@ my $resp = dancer_response GET => '/marco';
 my @req = ( [ GET => $route ], $route, $resp );
 
 test_helping_functions( $_ ) for @req;
+
+response_doesnt_exist [ GET => '/satisfaction' ], 'response_doesnt_exist';
+response_exists [ GET => '/marco' ], 'response_exists';
+
 
 sub test_helping_functions {
     my $req = shift;


### PR DESCRIPTION
(this pull depends on the inclusion of pull 475, aka the first commit of this pull)

The tests in their current state would always fail/pass, as the responses _do_ exist. They have a status of 404, but the response object itself exists.

Used the goto rather than fudging $Test::Builder::Level because I found it more readable here, but that can easily be swapped if other peeps prefer it.
