### PR TITLE
forward with params

### DIFF
--- a/lib/Dancer.pm
+++ b/lib/Dancer.pm
@@ -651,6 +651,16 @@ function, e.g.
 
 You probably always want to use C<return> with forward.
 
+Note that forward doesn't parse GET arguments. So, you can't use
+something like:
+
+     return forward '/home?authorized=1';
+
+But C<forward> supports an optional hash with parameters to be added
+to the actual parameters:
+
+     return forward '/home', { authorized => 1 };
+
 =head2 from_dumper ($structure)
 
 Deserializes a Data::Dumper structure.

--- a/lib/Dancer/Request.pm
+++ b/lib/Dancer/Request.pm
@@ -116,7 +116,7 @@ sub forward {
 
     my $new_request = $class->new($env);
     my $new_params  = _merge_params(scalar($request->params),
-                                    $to_data->{params});
+                                    $to_data->{params} || {});
 
     $new_request->{params}  = $new_params;
     $new_request->{body}    = $request->body;
@@ -128,28 +128,10 @@ sub forward {
 sub _merge_params {
     my ($params, $to_add) = @_;
 
-    my $result = {};
-    $result = $to_add if ref $to_add eq "HASH";
-
-    if (ref $to_add eq "ARRAY") {
-        while (@$to_add) {
-            my $key   = shift @$to_add;
-            my $value = shift @$to_add;
-
-            if (exists($result->{$key})) {
-                $result->{$key} = [$result->{$key}]
-                  unless ref $result->{$key} eq "ARRAY";
-                push @{$result->{$key}}, $value;
-            }
-            else {
-                $result->{$key} = $value;
-            }
-        }
+    die unless ref $to_add eq "HASH";
+    for my $key (keys %$to_add) {
+        $params->{$key} = $to_add->{$key};
     }
-    for my $key (keys %$result) {
-        $params->{$key} = $result->{$key};
-    }
-
     return $params;
 }
 

--- a/lib/Dancer/Response.pm
+++ b/lib/Dancer/Response.pm
@@ -65,7 +65,7 @@ sub has_passed {
 sub forward {
     my ($self, $uri, $params) = @_;
     $self->{forward} = { to_url => $uri,
-                         params => $params || [] };
+                         params => $params };
 }
 
 sub is_forwarded {

--- a/t/02_request/04_forward.t
+++ b/t/02_request/04_forward.t
@@ -15,11 +15,11 @@ use Dancer::Request;
 my $req = Dancer::Request->new(\%ENV);
 is $req->path, '/', 'path is /';
 is $req->method, 'GET', 'method is get';
-is_deeply scalar($req->params), {foo => 'bar', number => 42}, 
+is_deeply scalar($req->params), {foo => 'bar', number => 42},
     'params are parsed';
 
 $req = Dancer::Request->forward($req, { to_url => "/new/path"} );
 is $req->path, '/new/path', 'path is changed';
 is $req->method, 'GET', 'method is unchanged';
-is_deeply scalar($req->params), {foo => 'bar', number => 42}, 
+is_deeply scalar($req->params), {foo => 'bar', number => 42},
     'params are not touched';

--- a/t/03_route_handler/29_forward.t
+++ b/t/03_route_handler/29_forward.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 16, import => ['!pass'];
+use Test::More tests => 14, import => ['!pass'];
 
 use Dancer ':syntax';
 use Dancer::Logger;
@@ -22,11 +22,8 @@ get '/bounce/' => sub {
 get '/bounce/:withparams/' => sub {
     return forward '/';
 };
-get '/bounce2/adding_params_array/' => sub {
-    return forward '/', [ withparams => 'foo' ];
-};
-get '/bounce2/adding_params_hash/' => sub {
-    return forward '/', { withparams => 'bar' };
+get '/bounce2/adding_params/' => sub {
+    return forward '/', { withparams => 'foo' };
 };
 
 response_exists     [ GET => '/' ];
@@ -38,11 +35,8 @@ response_content_is [ GET => '/bounce/' ], 'home';
 response_exists     [ GET => '/bounce/thesethings/' ];
 response_content_is [ GET => '/bounce/thesethings/' ], 'homewithparams,thesethings';
 
-response_exists     [ GET => '/bounce2/adding_params_array/' ];
-response_content_is [ GET => '/bounce2/adding_params_array/' ], 'homewithparams,foo';
-
-response_exists     [ GET => '/bounce2/adding_params_hash/' ];
-response_content_is [ GET => '/bounce2/adding_params_hash/' ], 'homewithparams,bar';
+response_exists     [ GET => '/bounce2/adding_params/' ];
+response_content_is [ GET => '/bounce2/adding_params/' ], 'homewithparams,foo';
 
 my $expected_headers = [
     'Content-Length' => 4,


### PR DESCRIPTION
Yet another pull request that should be rejected soon O:-)

As discussed in #461, forward doesn't support parameters in the url. That is, 

```
 forward '/foo/bar?zbr=ugh';
```

will not work. The question there, was if this should be supported or not. I think not. But it should be documented.

In that discussion, @franckcuny suggested to support

```
 forward 'foo/bar', { zbr => 'ugh' }
```

or

```
 forward 'foo/bar', [ zbr => 'ugh' ]
```

This patch adds support to these two methods (together with tests).

_NOT_ included in this patch, we could also use

```
 forward 'foo/bar', zbr => 'ugh';
```

if you prefer this syntax let me know, and I'll change the code.

As soon as two devels agree that this is interesting and is to be merged, I'll be happy to add documentation to the PR before merging.

Cheers.
ambs
