### PR TITLE
qw dosn't create lists implicitly, now

### DIFF
--- a/t/09_cookies/03_persistence.t
+++ b/t/09_cookies/03_persistence.t
@@ -21,7 +21,7 @@ Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
 
-        foreach my $client qw(one two three) {
+        foreach my $client (qw(one two three)) {
             my $ua = LWP::UserAgent->new;
             $ua->cookie_jar({ file => "$tempdir/.cookies.txt" });
 

--- a/t/11_logger/01_abstract.t
+++ b/t/11_logger/01_abstract.t
@@ -10,9 +10,9 @@ use_ok 'Dancer::Logger::Abstract';
 
 my $l = Dancer::Logger::Abstract->new;
 isa_ok $l, 'Dancer::Logger::Abstract';
-can_ok $l, qw(_log _should debug warning error);
+can_ok $l, (qw(_log _should debug warning error));
 
-foreach my $method qw(_log debug warning error) {
+foreach my $method (qw(_log debug warning error)) {
     eval { $l->$method };
     like $@, qr/_log not implemented/, "$method is a virtual method";
 }

--- a/t/11_logger/02_factory.t
+++ b/t/11_logger/02_factory.t
@@ -25,7 +25,7 @@ ok(Dancer::Logger->init('file'), 'logger file initialized');
 $engine = Dancer::Logger->logger;
 isa_ok $engine, 'Dancer::Logger::File';
 
-foreach my $method qw(debug warning error) {
+foreach my $method (qw(debug warning error)) {
     ok(Dancer::Logger->$method("test"), "$method works");
 }
 


### PR DESCRIPTION
A couple of easy fixes on tests to not complain under Perl 5.14.0 that deprecates    qw() without the surrounding braces.
