### PR TITLE
Delete Warning when Dancer::Test test put method without body parameters

### DIFF
--- a/lib/Dancer/Test.pm
+++ b/lib/Dancer/Test.pm
@@ -309,7 +309,8 @@ Content-Type: text/plain
             $content =~ s/\n/\r\n/g;
         }
 
-        my $l = length $content;
+        my $l = 0;
+        $l = length $content if defined $content;
         open my $in, '<', \$content;
         $ENV{'CONTENT_LENGTH'} = $l;
         $ENV{'CONTENT_TYPE'}   = $content_type;


### PR DESCRIPTION
In dancer_response function of module Dancer::Test, when you test PUT method without body parameters, warning is display :

Use undef value $content in length function.
