### PR TITLE
add Plack to generated Makefile.pl

### DIFF
--- a/script/dancer
+++ b/script/dancer
@@ -331,9 +331,10 @@ WriteMakefile(
       : ()),
     PL_FILES            => {},
     PREREQ_PM => {
-        'Test::More' => 0,
-        'YAML'       => 0,
-        'Dancer'     => [% dancer_version %],
+        'Test::More'  => 0,
+        'YAML'        => 0,
+#       'Plack'       => 0,
+        'Dancer'      => [% dancer_version %],
     },
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean               => { FILES => '$cleanfiles-*' },


### PR DESCRIPTION
Yesterday @miyagawa asked on #dancer that is should be easier to add Plack (and YAML) to a generated app. I noticed that YAML is being added, already. This patch proposes to add Plack (commented out, as it doesn't seem required).

I do not think this solves the problem, but makes it easier to fix. 

Well, just an idea. Be free to delete this PR.
