### PR TITLE
15_plugins/02_config.t: disable logging to fix Win32 cleanup issue

### DIFF
--- a/t/15_plugins/02_config.t
+++ b/t/15_plugins/02_config.t
@@ -23,6 +23,7 @@ set(environment => 'test' );
 
 my $conffile = Dancer::Config->conffile;
 write_file( $conffile => << 'CONF' );
+logger: Null
 plugins:
   Test:
     foo: bar


### PR DESCRIPTION
15_plugins/02_config.t cleanup failed on Win32 due to a remaining opened log file.
This patch changes the app config to use the 'Null' logger instead of the
default 'File'.

My first Dancer patch :)
