### PR TITLE
Use relative URLs to images

### DIFF
--- a/script/dancer
+++ b/script/dancer
@@ -583,7 +583,7 @@ margin: 0;
 margin-bottom: 25px;
 padding: 0;
 background-color: #ddd;
-background-image: url("/images/perldancer-bg.jpg"); 
+background-image: url("../images/perldancer-bg.jpg"); 
 background-repeat: no-repeat;
 background-position: top left;
 
@@ -634,7 +634,7 @@ padding-right: 30px;
 
 
 #header {
-background-image: url("/images/perldancer.jpg"); 
+background-image: url("../images/perldancer.jpg");
 background-repeat: no-repeat;
 background-position: top left;
 height: 64px;


### PR DESCRIPTION
Was starting a new project to be hosted under a specific path (http://host/app). Created the app (dancer -a) and configured apache, and everything went fine... but the images. CSS file links images to /images/foo and I needed /app/images/foo.

This patch changes these paths (just two) to relative paths. Therefore, the default application should _just_ work in any environment. (hopefully).
