### PR TITLE
Remove deprecation of 18 Feb

### DIFF
--- a/lib/Dancer/Handler/PSGI.pm
+++ b/lib/Dancer/Handler/PSGI.pm
@@ -69,20 +69,11 @@ sub apply_plack_middlewares {
 
     my $builder = Plack::Builder->new();
 
-    # XXX remove this after 1.2
-    if ( ref $middlewares eq 'HASH' ) {
-        Dancer::Deprecation->deprecated(
-            fatal   => 1,
-            feature => 'Listing Plack middlewares as a hash ref',
-            reason  => 'Must be listed as an array ref',
-        );
-    }
-    else {
-        map {
-            Dancer::Logger::core "add middleware " . $_->[0];
-            $builder->add_middleware(@$_)
-        } @$middlewares;
-    }
+    die unless ref $middlewares eq "ARRAY";
+    map {
+        Dancer::Logger::core "add middleware " . $_->[0];
+        $builder->add_middleware(@$_)
+    } @$middlewares;
 
     $app = $builder->to_app($app);
 


### PR DESCRIPTION
Probably this was too soon, I just checked the log after prearing the PR.
This code was carping for some time. It got croaking in 18 January, and got deprecated as fatal in 18 Feb.

Maintained a die just in case. Should I remove it?

Cheers.
