### PR TITLE
Deprecate mime_type

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,8 @@
     * Deprecate 'layout' (use set). (Alberto Simões)
     * Definitely remove plack_middlewares HashRef deprecation.
       (Alberto Simões & Damien Krotkine)
+    * Second level of deprecation for mime_type method.
+      (Alberto Simões)
 
     [ ENHANCEMENTS ]
     * GH #519: remove redundant lines from CSS

--- a/lib/Dancer.pm
+++ b/lib/Dancer.pm
@@ -61,7 +61,6 @@ our @EXPORT    = qw(
   load_app
   logger
   mime
-  mime_type
   options
   params
   pass
@@ -136,9 +135,6 @@ sub logger          {
     set(logger => @_)
 }
 sub mime            { Dancer::MIME->instance() }
-sub mime_type       {
-    Dancer::Deprecation->deprecated(reason => "use 'mime' from Dancer.pm",fatal => 1)
-}
 sub options         { Dancer::App->current->registry->universal_add('options', @_) }
 sub params          { Dancer::SharedData->request->params(@_) }
 sub pass            { Dancer::SharedData->response->pass(1) }

--- a/lib/Dancer/Config.pm
+++ b/lib/Dancer/Config.pm
@@ -13,7 +13,7 @@ use Carp;
 
 use Encode;
 
-@EXPORT_OK = qw(setting mime_types);
+@EXPORT_OK = qw(setting);
 
 my $SETTINGS = {};
 
@@ -84,13 +84,6 @@ my $normalizers = {
         return $name;
     },
 };
-
-sub mime_types {
-    Dancer::Deprecation->deprecated(
-        reason => "use 'mime' from Dancer.pm",
-        fatal => 1,
-    );
-}
 
 sub normalize_setting {
     my ($class, $setting, $value) = @_;

--- a/lib/Dancer/MIME.pm
+++ b/lib/Dancer/MIME.pm
@@ -66,24 +66,21 @@ sub for_name {
 }
 
 sub add_mime_type {
-    my ($self, $name, $type) = @_;
     Dancer::Deprecation->deprecated(feature => 'add_mime_type',
+                                    fatal => 1,
                                     reason => 'use the new "add" method');
-    $self->add_type($name => $type);
 }
 
 sub add_mime_alias {
-    my ($self, $alias, $orig) = @_;
     Dancer::Deprecation->deprecated(feature => 'add_mime_alias',
+                                    fatal => 1,
                                     reason => 'use the new "add_alias" method');
-    $self->add_alias($alias => $orig);
 }
 
 sub mime_type_for {
-    my ($self, $content_type) = @_;
     Dancer::Deprecation->deprecated(feature => 'mime_type_for',
+                                    fatal => 1,
                                     reason => 'use the new "name_or_type" method');
-    return $self->name_or_type($content_type);
 }
 
 42;


### PR DESCRIPTION
We have a bunch of methods deprecated since 1.3030.
Already fatal:

```
  mime_type @ lib/Dancer.pm
  mime_types @ lib/Dancer/Config.pm
```

Still soft:

```
   add_mime_type  @ lib/Dancer/MIME.pm
   add_mime_alias  @ lib/Dancer/MIME.pm
   mime_type_for  @ lib/Dancer/MIME.pm
```

This patch goes to the next level: removed the first two, make fatal the last three.
I think there shouldn't be much people around using this. When you think this should be applied, tell! Meanwhile, let the PR hang around.
