### PR TITLE
Add lexical prefix

### DIFF
--- a/lib/Dancer.pm
+++ b/lib/Dancer.pm
@@ -1043,6 +1043,16 @@ You can unset the prefix value:
     prefix undef;
     get '/page1' => sub {}; will match /page1
 
+For a safer alternative you can use lexical prefix like this:
+
+    prefix '/home' => sub {
+        ## Prefix is set to '/home' here
+        
+        get ...;
+        get ...;
+    };
+    ## prefix reset to the previous version here
+
 B<Notice:> once you have a prefix set, do not add a caret to the regex:
 
     prefix '/foo';

--- a/lib/Dancer/App.pm
+++ b/lib/Dancer/App.pm
@@ -29,10 +29,17 @@ sub set_running_app {
 }
 
 sub set_prefix {
-    my ($self, $prefix) = @_;
+    my ($self, $prefix, $cb) = @_;
     croak "not a valid prefix: `$prefix', must start with a /"
       if defined($prefix) && $prefix !~ /^\//;
+    my $previous = Dancer::App->current->prefix;
     Dancer::App->current->prefix($prefix);
+    if (ref($cb) eq 'CODE') {
+        eval { $cb->() };
+        my $e = $@;
+        Dancer::App->current->prefix($previous);
+        die $e if $e;
+    }
     return 1;    # prefix may have been set to undef
 }
 

--- a/lib/Dancer/Introduction.pod
+++ b/lib/Dancer/Introduction.pod
@@ -166,6 +166,14 @@ You can unset the prefix value
     prefix undef;
     get '/page1' => sub {}; will match /page1
 
+Alternatively, to prevent you from ever forgetting to undef the prefix,
+you can use lexical prefix like this:
+
+    prefix '/home' => sub {
+      get '/page1' => sub {}; # will match '/home/page1'
+    }; ## prefix reset to previous value on exit
+    
+    get '/page1' => sub {}; will match /page1
 
 =head2 RUNNING THE WEBSERVER
 

--- a/t/03_route_handler/15_prefix.t
+++ b/t/03_route_handler/15_prefix.t
@@ -3,7 +3,7 @@ use Dancer ':syntax';
 use Dancer::Test;
 use Dancer::Route;
 
-plan tests => 21;
+plan tests => 25;
 
 eval { prefix 'say' };
 like $@ => qr/not a valid prefix/, 'prefix must start with a /';
@@ -25,6 +25,10 @@ like $@ => qr/not a valid prefix/, 'prefix must start with a /';
         "number: " . params->{number};
     };
 
+    prefix '/lex' => sub {
+      get '/foo'  => sub { 'it worked' };
+    };
+
     any '/any' => sub {"any"};
 
     get qr{/_(.*)} => sub {
@@ -42,6 +46,10 @@ like $@ => qr/not a valid prefix/, 'prefix must start with a /';
 
     prefix(undef);
 
+    prefix '/dura' => sub {
+      get '/us'  => sub { 'us worked' };
+    };
+
     get '/*' => sub {
         "trash: " . params->{splat}[0];
     };
@@ -58,6 +66,8 @@ my @tests = (
     { path => '/go_to_trash', expected => 'trash: go_to_trash' },
     { path => '/say/foo',     expected => 'it worked' },
     { path => '/say/foo/',    expected => 'it worked' },
+    { path => '/lex/foo',     expected => 'it worked' },
+    { path => '/dura/us',     expected => 'us worked' },
 );
 
 foreach my $test (@tests) {


### PR DESCRIPTION
The prefix is set globally and if I forget the matching prefix undef; it could poison actions added in another lexical context later on.

This commit introduces lexical prefixes. To use, you pass a second coderef to prefix. The coderef will be immediately executed with the desired prefix active. At the end of the execution, the prefix will be reseted to the original value.

Signed-off-by: Pedro Melo melo@simplicidade.org
