### PR TITLE
Pr/one arg request errors

### DIFF
--- a/lib/Dancer/Request.pm
+++ b/lib/Dancer/Request.pm
@@ -15,10 +15,15 @@ use URI;
 use URI::Escape;
 
 sub new {
-    # To provide good error messages for those burnt by upgrading.
+    # Deprecate the one arg style of initialization.
     my ($self, @args) = @_;
     if (@args == 1) {
-        croak 'Attempt to instantiate a request object with a single argument - the syntax has changed to Dancer::Request->new(env => $env)';
+        @args = ('env' => $args[0]);
+        Dancer::Deprecation->deprecated(
+            feature => 'Calling Dancer::Request->new($env)',
+            version => 1.3052,
+            reason => 'Please use Dancer::Request->new( env => $env ) instead',
+        );
     }
     $self->SUPER::new(@args);
 }

--- a/t/02_request/06_init_env.t
+++ b/t/02_request/06_init_env.t
@@ -4,6 +4,7 @@ use strict;
 use warnings FATAL => 'all';
 
 use Dancer::Request;
+use Test::Warn;
 
 my $custom_env = {
     'SERVER_PORT'    => 3000,
@@ -22,7 +23,7 @@ my $custom_env = {
     'HTTP_CONNECTION' => 'keep-alive; keep-alive',
 };
 my @http_env = grep /^HTTP_/, keys (%$custom_env);
-plan tests => 6 + (2 * scalar(@http_env));
+plan tests => 10 + (2 * scalar(@http_env));
 
 my $req = Dancer::Request->new(env => $custom_env);
 is $req->path, '/stuff', 'path is set from custom env';
@@ -40,3 +41,9 @@ foreach my $http (@http_env) {
     is $req->$key, $custom_env->{$http}, "$key is an accessor";
 }
 
+my $expected_warning = qr/Please use Dancer::Request->new\( env => \$env \)/;
+warning_like {$req = Dancer::Request->new($custom_env);} $expected_warning, 
+    "Provides good errors about old usage syntax";
+is $req->path, '/stuff', 'path is set from custom env';
+is $req->method, 'GET', 'method is set from custom env';
+is_deeply scalar($req->params), {foo => 'bar'}, 'params are set from custom env';

--- a/t/02_request/19_one_arg_instantiation.t
+++ b/t/02_request/19_one_arg_instantiation.t
@@ -1,8 +1,0 @@
-use Test::More tests => 1;
-use Test::Exception;
-
-use Dancer::Request;
-
-my $env = {};
-my $expected = qr/Attempt to instantiate a request object with a single argument/;
-throws_ok {Dancer::Request->new($env);} $expected, "Provides good errors about old usage syntax";


### PR DESCRIPTION
This is a patch to provide meaningful errors to explain why working code breaks when upgrading to the latest version of Dancer. The changes to Request instantiation will mean that code that works now will throw obscure error messages (odd number of elements in hashref, and the like). Since these users have been nice to Dancer so far, Dancer should be nice to them and tell them when things change under their feet.
