### PR TITLE
Remove extra / from lib location in default template

### DIFF
--- a/script/dancer
+++ b/script/dancer
@@ -470,7 +470,7 @@ WriteMakefile(
               it\'s just here to help you get started. The template used to
               generate this content is located in 
               <code>views/index.tt</code>.
-              You can add some routes to <tt>lib/'.$LIB_PATH.'/'.$LIB_FILE.'</tt>. 
+              You can add some routes to <tt>lib'.$LIB_PATH.'/'.$LIB_FILE.'</tt>.
               </p>
             </li>
 


### PR DESCRIPTION
Noticed a double // in the lib location in the default template after creating a new dancer application.
