### PR TITLE
Do not reload config files if they are already loaded

### DIFF
--- a/lib/Dancer/Config.pm
+++ b/lib/Dancer/Config.pm
@@ -19,6 +19,7 @@ my $SETTINGS = {};
 
 # mergeable settings
 my %MERGEABLE = map { ($_ => 1) } qw( plugins handlers );
+my %_LOADED;
 
 sub settings {$SETTINGS}
 
@@ -176,10 +177,16 @@ sub load {
     confess "Configuration file found but YAML is not installed"
       unless Dancer::ModuleLoader->load('YAML');
 
-    load_settings_from_yaml(conffile);
+    if (!$_LOADED{conffile()}) {
+        load_settings_from_yaml(conffile);
+        $_LOADED{conffile()}++;
+    }
 
     my $env = environment_file;
-    load_settings_from_yaml($env) if -f $env;
+    if (-f $env && !$_LOADED{$env}) {
+        load_settings_from_yaml($env);
+        $_LOADED{$env}++;
+    }
 
     foreach my $key (grep { $setters->{$_} } keys %$SETTINGS) {
         $setters->{$key}->($key, $SETTINGS->{$key});


### PR DESCRIPTION
First, forget the name of the branch :)

Second, this fixes #265, by not loading a config file that was already loaded.

Basically, ATM, when you `use Dancer;` import will load config files. When you issue `dance()` config files are reloaded. I am not sure if this behavior is correct (probably for multi-apps this is needed?). I do not "fix" it, I just cache the names of the config files that were already loaded.

Note that although this fixes #265, it doesn't solve the problem if the user says:

```
 set environment => "bar";
 set template => "template_toolkit";
```

and the environment config file replaces the template var. But this one doesn't seem _that_ relevant.

But open to comments.
