### PR TITLE
disabled the network parts of the dancer minting tests

### DIFF
--- a/t/19_dancer/01_script.t
+++ b/t/19_dancer/01_script.t
@@ -44,7 +44,6 @@ my $help = qx{$cmd};
 like($help, qr{Usage: .* dancer .* options}sx, 'dancer (without parameters)');
 
 foreach my $case (@cases) {
-    my $create_here = qx{$cmd -a $case 2> err};
+    my $create_here = qx{$cmd -x -a $case 2> err};
     ok (-z 'err', "create $case did not return error");
 }
-

--- a/t/19_dancer/02_script_version_from.t
+++ b/t/19_dancer/02_script_version_from.t
@@ -33,7 +33,7 @@ foreach my $case ( keys %cases ) {
     my ( $casedir, $casefile ) = @{ $cases{$case} };
 
     # create the app
-    qx{$cmd -a $case};
+    qx{$cmd -x -a $case};
 
     # check for directory
     my $exists = -d $casedir;


### PR DESCRIPTION
When using /etc/hosts to replace s.c.o with metacpan, the version check of script/dancer breaks, which also means that the tests for Dancer minting break. This change sets those tests to run without that check so it can be installed even if the real cpan is not available.
