### PR TITLE
support xml as text

### DIFF
--- a/lib/Dancer/Handler.pm
+++ b/lib/Dancer/Handler.pm
@@ -174,7 +174,7 @@ sub render_response {
 
 sub _is_text {
     my ($content_type) = @_;
-    return $content_type =~ /(xml|text|json)/;
+    return $content_type =~ /(x(?:ht)?ml|text|json|javascript)/;
 }
 
 # Fancy banner to print on startup


### PR DESCRIPTION
It seems that there are two content types allowed for XML: application/xml and text/xml. The first was not recognized by Dancer (so it did not encode the text correctly).

This fixes it.
