### PR TITLE
Remove default engine section from Dancer::Serializer's POD as default is

### DIFF
--- a/lib/Dancer/Serializer.pm
+++ b/lib/Dancer/Serializer.pm
@@ -118,13 +118,6 @@ serializers.
 
 =head1 USAGE
 
-=head2 Default engine
-
-The default serializer used by Dancer::Serializer is
-L<Dancer::Serializer::JSON>.
-You can choose another serializer by setting the B<serializer> configuration
-variable.
-
 =head2 Configuration
 
 The B<serializer> configuration variable tells Dancer which serializer to use


### PR DESCRIPTION
Remove default engine section from Dancer::Serializer's POD as default is no serialization.
