### PR TITLE
Typo fix in Dancer.pm POD

### DIFF
--- a/lib/Dancer.pm
+++ b/lib/Dancer.pm
@@ -563,7 +563,7 @@ tokens that will be inserted into the template.
 This filter works as the C<before> and C<after> filter.
 
 Now the preferred way for this is to use C<hook>s (namely, the
-C<before_template> one). Check C<hook> documentation bellow.
+C<before_template> one). Check C<hook> documentation below.
 
 =head2 cookies
 


### PR DESCRIPTION
Trivial fix to fix the spelling of "below" in the documentation of the `params` method.
