### PR TITLE
Corrected logic when testing for the presence of the conffile.

### DIFF
--- a/lib/Dancer/Config.pm
+++ b/lib/Dancer/Config.pm
@@ -171,7 +171,7 @@ sub load {
     init_confdir();
 
     # look for the conffile
-    return 1 unless -f conffile;
+    return 1 if not -f conffile;
 
     # load YAML
     confess "Configuration file found but YAML is not installed"


### PR DESCRIPTION
Corrected logic when testing for the presence of the conffile.  I believe this is the intended logic.  Otherwise, you get a warning about concatenating an uninitialized value down in File::Spec.
