### PR TITLE
Regularize spacing & fix rewrite rule

### DIFF
--- a/lib/Dancer/Deployment.pod
+++ b/lib/Dancer/Deployment.pod
@@ -21,23 +21,23 @@ sites-available/*site*):
     <VirtualHost *:80>
         ServerName www.example.com
         DocumentRoot /srv/www.example.com/public
-    	ServerAdmin you@example.com
+        ServerAdmin you@example.com
 
-   		<Directory "/srv/www.example.com/public">
+        <Directory "/srv/www.example.com/public">
            AllowOverride None
            Options +ExecCGI -MultiViews +SymLinksIfOwnerMatch
            Order allow,deny
            Allow from all
            AddHandler cgi-script .cgi
-   		</Directory>
+        </Directory>
 
-   		RewriteEngine On
-   		RewriteCond %{REQUEST_FILENAME} !-f
-   		RewriteRule ^(.*)$ /dispatch.fcgi$1 [QSA,L]
+        RewriteEngine On
+        RewriteCond %{REQUEST_FILENAME} !-f
+        RewriteRule ^(.*)$ /dispatch.cgi$1 [QSA,L]
 
         ErrorLog  /var/log/apache2/www.example.com-error.log
         CustomLog /var/log/apache2/www.example.com-access_log common
-	</VirtualHost>
+    </VirtualHost>
 
 Here, the mod_rewrite magic for Pretty-URLs is directly put in Apache's configuration. 
 But if your web server supports .htaccess files, you can drop those lines in a .htaccess file.


### PR DESCRIPTION
The example is about running a Dancer app as a CGI and it adds a handler
for files that end in .cgi, but the RewriteRule was for dispatch.fcgi,
rather than dispatch.cgi
