### PR TITLE
Fix #589: detect appdir correctly if script is in t/

### DIFF
--- a/lib/Dancer.pm
+++ b/lib/Dancer.pm
@@ -258,10 +258,11 @@ sub _init_script_dir {
 
     my $LAYOUT_PRE_DANCER_1_2 = 1;
 
-    # in bin/ or public/ we need to go one level upper to find the appdir
+    # in bin/ or public/ or t/ we need to go one level upper to find the appdir
     $LAYOUT_PRE_DANCER_1_2 = 0
       if ($script_dirs[$#script_dirs - 1] eq 'bin')
-      or ($script_dirs[$#script_dirs - 1] eq 'public');
+      or ($script_dirs[$#script_dirs - 1] eq 'public')
+      or ($script_dirs[$#script_dirs - 1] eq 't');
 
     my $appdir = $ENV{DANCER_APPDIR} || (
           $LAYOUT_PRE_DANCER_1_2


### PR DESCRIPTION
I´m not really sure if the attached test in the issue is actually a valid case. Anyway, it looks like there´s special treatment if the running script is in public/ or bin/. If we treat t/ just like that, the sample test case (and Dancer´s own tests) pass.
