### PR TITLE
Fix #663: Standalone handler tests broken

### DIFF
--- a/t/07_apphandlers/04_standalone_app.t
+++ b/t/07_apphandlers/04_standalone_app.t
@@ -38,12 +38,8 @@ Test::TCP::test_tcp(
         use lib File::Spec->catdir( 't', 'lib' );
         use TestApp;
         Dancer::Config->load;
-        set( environment  => 'production',
-             startup_info => 0,
-             port         => $port,
-             apphandler   => 'PSGI');
-        my $app = Dancer::Handler->psgi_app;
-        Plack::Loader->auto( port => $port)->run($app);
+        set( port         => $port,
+             startup_info => 0 );
         Dancer->dance();
     },
 );


### PR DESCRIPTION
This should force using the Standalone handler. In the Standalone handler tests.
