### PR TITLE
Deployment pod: warn against mutliple apps with Plack.

### DIFF
--- a/lib/Dancer/Deployment.pod
+++ b/lib/Dancer/Deployment.pod
@@ -437,6 +437,8 @@ To set the environment you want to use for your application (production or devel
         ...
     </VirtualHost>
 
+B<NOTE:> Only a single Dancer application can be deployed using the C<Plack::Handler::Apache2> method. Multiple Dancer applications B<will not work properly> (The routes will be mixed-up between the applications).
+
 =head3 Running from Apache under appdir
 
 If you want to deploy multiple applications under the same VirtualHost, using


### PR DESCRIPTION
Hello Alexis,

This tiny patch adds a warning to the deployment guide, warning users from using multiple apps with "Plack::Handler::Apache2".

Hopefully will save others some time and wasted effort...

Thanks,
 -gordon
