### PR TITLE
Update lib/Dancer/Logger/Abstract.pm

### DIFF
--- a/lib/Dancer/Logger/Abstract.pm
+++ b/lib/Dancer/Logger/Abstract.pm
@@ -92,7 +92,7 @@ sub format_message {
               ? $r->env->{'HTTP_X_REAL_IP'} || $r->env->{'REMOTE_ADDR'}
               : '-';
         },
-        t => sub { Encode::decode(setting('charset'),
+        t => sub { Encode::decode(setting('charset') || 'utf8',
                                   POSIX::strftime( "%d/%b/%Y %H:%M:%S", localtime )) },
         T => sub { POSIX::strftime( "%Y-%m-%d %H:%M:%S", localtime  ) },
         P => sub { $$ },


### PR DESCRIPTION
UTF-8 in logger format "%t" by default. Otherwise we have a crash "Unknown encoding at Dancer/Logger/Abstract.pm line 95"
