### PR TITLE
Better support complex views

### DIFF
--- a/lib/Dancer/Template/Abstract.pm
+++ b/lib/Dancer/Template/Abstract.pm
@@ -257,6 +257,17 @@ configuration. For example, for the default (C<Simple>) engine:
 
 The default behavior of this method is to return the path of the given view.
 
+=item B<view_exists($view_path)>
+
+By default, Dancer::Template::Abstract checks to see if it can find the
+view file calling C<view_exists($path_to_file)>. If not, it will
+generate a nice error message for the user.
+
+If you are using extending Dancer::Template::Abstract to use a template
+system with multiple document roots (like L<Text::XSlate> or
+L<Template>), you can override this method to always return true, and
+therefore skip this check.
+
 =item B<layout($layout, $tokens, $content)>
 
 The default behavior of this method is to merge a content with a layout.


### PR DESCRIPTION
Since c5ec2cd Dancer checks the filesystem to see if the view exists.

This works for simple template engines, but complex ones can have multiple template roots and search all of them for the view. Some even have virtual or remote template roots.

This small patch just moves the filesystem check to a separate method. This allows complex views to override it and return true, bypassing this check.
