### PR TITLE
Expanding file uploading testing of Dancer::Test

### DIFF
--- a/lib/Dancer/Test.pm
+++ b/lib/Dancer/Test.pm
@@ -13,6 +13,7 @@ use Dancer ':syntax', ':tests';
 use Dancer::App;
 use Dancer::Deprecation;
 use Dancer::Request;
+use Dancer::Request::Upload;
 use Dancer::SharedData;
 use Dancer::Renderer;
 use Dancer::Handler;

--- a/t/23_dancer_tests/02_tests_functions.t
+++ b/t/23_dancer_tests/02_tests_functions.t
@@ -3,7 +3,7 @@ use warnings;
 
 use Test::More;
 
-plan tests => 28;
+plan tests => 29;
 
 use Dancer qw/ :syntax :tests /;
 use Dancer::Test;
@@ -41,6 +41,10 @@ del '/user/:id' => sub {
 
 get '/query' => sub {
     return join(":",params('query'));
+};
+
+post '/upload' => sub {
+	return upload('payload')->content;
 };
 
 my $resp = dancer_response GET => '/marco';
@@ -88,3 +92,11 @@ is_deeply $r->{content}, { user => { id => 2, name => "Franck Cuny" } },
 
 $r = dancer_response( GET => '/query', { params => {foo => 'bar'}});
 is $r->{content} => "foo:bar";
+
+my $data = "She sells sea shells by the sea shore";
+$r = dancer_response(
+	POST => '/upload', 
+	{ files => [{name => 'payload', filename =>'test.txt', data => $data }] }
+);
+is $r->{content}, $data, "file data uploaded";
+


### PR DESCRIPTION
What's here:
- The ability for dancer_response to send file contents for file uploads as a scalar, instead of reading from file on disk
- Testing for the above, upload() works now

What's not:
- Testing of file uploads that read data from the file (although its possible now)
- uploads() still doesn't work, I haven't had time to get that functioning
- Support for passing file handles, I may make this a another pull request another time
