### PR TITLE
behind proxy an X-Forwarded-Host

### DIFF
--- a/lib/Dancer/Request.pm
+++ b/lib/Dancer/Request.pm
@@ -56,7 +56,7 @@ sub host {
         $_[0]->{host} = $_[1];
     } else {
         my $host;
-        $host = $_[0]->env->{X_FORWARDED_HOST} if setting('behind_proxy');
+        $host = ($_[0]->env->{X_FORWARDED_HOST} || $_[0]->env->{HTTP_X_FORWARDED_HOST}) if setting('behind_proxy');
         $host || $_[0]->{host} || $_[0]->env->{HTTP_HOST};
     }
 }


### PR DESCRIPTION
When we are behind proxy, we use  X-Forwarded-Host for constructing urls.
As it's written in apache mod_proxy docs, apache should add X-Forwarded-Host request header while redirecting.
But it isn't. HTTP-X-Forwarded-Host is being created by apache.
This small fix takes care about it.
