### PR TITLE
Caching of routes now takes account of application name of route (differ...

### DIFF
--- a/lib/Dancer/App.pm
+++ b/lib/Dancer/App.pm
@@ -123,7 +123,7 @@ sub find_route {
     # if route cache is enabled, we check if we handled this path before
     if (Dancer::Config::setting('route_cache')) {
         my $route = Dancer::Route::Cache->get->route_from_path($method,
-            $request->path_info);
+            $request->path_info, $self->name);
 
         # NOTE maybe we should cache the match data as well
         if ($route) {
@@ -143,7 +143,7 @@ sub find_route {
             # if we have a route cache, store the result
             if (Dancer::Config::setting('route_cache')) {
                 Dancer::Route::Cache->get->store_path($method,
-                    $request->path_info => $r);
+                    $request->path_info => $r, $self->name);
             }
 
             return $r;

--- a/t/03_route_handler/16_caching.t
+++ b/t/03_route_handler/16_caching.t
@@ -109,7 +109,7 @@ $cache->{'cache_array'} = [];
     cmp_ok( $cache->route_cache_paths, '==', 10, 'Path limit to 10' );
 
     # because we use a FIFO method, we know which ones they are
-    my @expected_paths = map { [ 'get', "/$_" ] } 'q' .. 'z';
+    my @expected_paths = map { [ 'get', "/$_", 'main' ] } 'q' .. 'z';
 
     is_deeply(
         $cache->{'cache_array'},
@@ -153,7 +153,7 @@ SKIP: {
 
     # because we use a FIFO method, we know which ones they are
     shift @paths;
-    my @expected_paths = map { [ 'get', $_ ] } @paths;
+    my @expected_paths = map { [ 'get', $_, 'main' ] } @paths;
 
     is_deeply(
         $cache->{'cache_array'},


### PR DESCRIPTION
I found buggy code in Dancer
A routes are linked with applications.
But cache of routes doen't take account of application - only path & method of request
But application name must be taken into account too

Here patch for it
All tests are passed after this patch

Without this patch it works fine until out applications live in one world of URL mapping. But if we will use builder & mount commands of Plack::Builder this will be bad
