### PR TITLE
fix 'uninitialized value' warn for $version

### DIFF
--- a/lib/Dancer/Handler/Standalone.pm
+++ b/lib/Dancer/Handler/Standalone.pm
@@ -54,7 +54,7 @@ sub print_startup_info {
         $module =~ s{/}{::}g;  # change / to ::
         $module =~ s{\.pm$}{}; # remove .pm at the end
 
-        my $version = $module->VERSION;
+        my $version = $module->VERSION || '';
         print ">> $module ($version)\n";
     }
 


### PR DESCRIPTION
for prevent warnings like:

> > Dancer 1.3080 server 11576 listening on http://0.0.0.0:3000
> > Use of uninitialized value $version in concatenation (.) or string at /usr/lib64/perl5/vendor_perl/5.12.4/Dancer/Handler/Standalone.pm line 58, <DATA> line 16.
> > Dancer::Plugin::Ajax ()
> > == Entering the development dance floor ...
