### PR TITLE
Add server_emit config option.

### DIFF
--- a/lib/Dancer/Config.pm
+++ b/lib/Dancer/Config.pm
@@ -220,19 +220,19 @@ sub load_settings_from_yaml {
 }
 
 sub load_default_settings {
-    $SETTINGS->{server}       ||= $ENV{DANCER_SERVER}       || '0.0.0.0';
-    $SETTINGS->{port}         ||= $ENV{DANCER_PORT}         || '3000';
-    $SETTINGS->{content_type} ||= $ENV{DANCER_CONTENT_TYPE} || 'text/html';
-    $SETTINGS->{charset}      ||= $ENV{DANCER_CHARSET}      || '';
-    $SETTINGS->{startup_info} ||= $ENV{DANCER_STARTUP_INFO} || 1;
-    $SETTINGS->{daemon}       ||= $ENV{DANCER_DAEMON}       || 0;
-    $SETTINGS->{apphandler}   ||= $ENV{DANCER_APPHANDLER}   || 'Standalone';
-    $SETTINGS->{warnings}     ||= $ENV{DANCER_WARNINGS}     || 0;
-    $SETTINGS->{auto_reload}  ||= $ENV{DANCER_AUTO_RELOAD}  || 0;
-    $SETTINGS->{traces}       ||= $ENV{DANCER_TRACES}       || 0;
-    $SETTINGS->{server_emit}  ||= $ENV{DANCER_SERVER_EMIT}  || 1;
-    $SETTINGS->{logger}       ||= $ENV{DANCER_LOGGER}       || 'file';
-    $SETTINGS->{environment} ||=
+    $SETTINGS->{server}        ||= $ENV{DANCER_SERVER}        || '0.0.0.0';
+    $SETTINGS->{port}          ||= $ENV{DANCER_PORT}          || '3000';
+    $SETTINGS->{content_type}  ||= $ENV{DANCER_CONTENT_TYPE}  || 'text/html';
+    $SETTINGS->{charset}       ||= $ENV{DANCER_CHARSET}       || '';
+    $SETTINGS->{startup_info}  ||= $ENV{DANCER_STARTUP_INFO}  || 1;
+    $SETTINGS->{daemon}        ||= $ENV{DANCER_DAEMON}        || 0;
+    $SETTINGS->{apphandler}    ||= $ENV{DANCER_APPHANDLER}    || 'Standalone';
+    $SETTINGS->{warnings}      ||= $ENV{DANCER_WARNINGS}      || 0;
+    $SETTINGS->{auto_reload}   ||= $ENV{DANCER_AUTO_RELOAD}   || 0;
+    $SETTINGS->{traces}        ||= $ENV{DANCER_TRACES}        || 0;
+    $SETTINGS->{server_tokens} ||= $ENV{DANCER_SERVER_TOKENS} || 1;
+    $SETTINGS->{logger}        ||= $ENV{DANCER_LOGGER}        || 'file';
+    $SETTINGS->{environment}   ||=
          $ENV{DANCER_ENVIRONMENT}
       || $ENV{PLACK_ENV}
       || 'development';
@@ -446,7 +446,7 @@ If set to true, tells Dancer to consider all warnings as blocking errors.
 If set to true, Dancer will display full stack traces when a warning or a die
 occurs. (Internally sets Carp::Verbose). Default to false.
 
-=head3 server_emit (boolean)
+=head3 server_tokens (boolean)
 
 If set to true, Dancer will add an "X-Powered-By" header and also append
 the Dancer version to the "Server" header. Default to true.

--- a/lib/Dancer/Renderer.pm
+++ b/lib/Dancer/Renderer.pm
@@ -56,7 +56,7 @@ sub render_error {
 sub response_with_headers {
     my $response = Dancer::SharedData->response();
 
-    if (Dancer::Config::setting('server_emit')) {
+    if (Dancer::Config::setting('server_tokens')) {
         $response->{headers} ||= HTTP::Headers->new;
         my $powered_by = "Perl Dancer " . $Dancer::VERSION;
         $response->header('X-Powered-By' => $powered_by);


### PR DESCRIPTION
If set to true, Dancer will add an "X-Powered-By" header and also append
the Dancer version to the "Server" header. Default to true.

Should fix #652.
