### PR TITLE
Fix the example for optional route parameters

### DIFF
--- a/lib/Dancer/Introduction.pod
+++ b/lib/Dancer/Introduction.pod
@@ -127,7 +127,7 @@ be set in the params hashref.
 Tokens can be optional, for example:
 
     get '/hello/:name?' => sub {
-        "Hello there " . param('name') || "whoever you are!";
+        "Hello there " . (param('name') || "whoever you are!");
     };
 
 


### PR DESCRIPTION
In Dancer::Introduction, the second example in the "Named Matching" section doesn't work correctly and produces a warning. Adding parentheses around `param('name') || "whoever you are!"` fixes the problem.
