### PR TITLE
Dancer::Error::_censor on structures with loops? boom

### DIFF
--- a/lib/Dancer/Error.pm
+++ b/lib/Dancer/Error.pm
@@ -136,7 +136,14 @@ sub dumper {
 
 # Given a hashref, censor anything that looks sensitive.  Returns number of
 # items which were "censored".
+our $CENSOR_LEVEL = 0;
+
 sub _censor {
+    local $Dancer::Error::CENSOR_LEVEL = 1 + $Dancer::Error::CENSOR_LEVEL;
+
+    warn "data exceeding 100 levels, truncating\n"
+        and return shift if $Dancer::Error::CENSOR_LEVEL > 100;
+
     my $hash = shift;
     if (!$hash || ref $hash ne 'HASH') {
         carp "_censor given incorrect input: $hash";

--- a/t/12_response/10_error_dumper.t
+++ b/t/12_response/10_error_dumper.t
@@ -31,5 +31,14 @@ is(
     'Original data was not overwritten',
 );
 
+my %recursive;
+$recursive{foo}{bar}{baz} = 1;
+$recursive{foo}{bar}{oops} = $recursive{foo};
+
+$censored = Dancer::Error::_censor( \%recursive );
+
+pass "recursive censored hash";
+
+
 1;
 


### PR DESCRIPTION
Discovered the problem with https://rt.cpan.org/Ticket/Display.html?id=73981

_censor descends the hash without checking for recursions, so something like

   $oops{foo}{bar}{baz} = $ooops{foo};

will not result in fun and happiness. 

There's probably a more elegant way to deal with it, but that's a start. :-)
