### PR TITLE
Deployment config for multiple apps fails

### DIFF
--- a/lib/Dancer/Deployment.pod
+++ b/lib/Dancer/Deployment.pod
@@ -180,8 +180,8 @@ Start by creating a simple app.psgi file:
         my $env = shift;
         local $ENV{DANCER_APPDIR} = '/Users/franck/tmp/app1';
         load_app "app1";
-        Dancer::App->set_running_app('app1');
         setting appdir => '/Users/franck/tmp/app1';
+        Dancer::App->set_running_app('app1');
         Dancer::Config->load;
         my $request = Dancer::Request->new( env => $env );
         Dancer->dance($request);
@@ -191,8 +191,8 @@ Start by creating a simple app.psgi file:
         my $env = shift;
         local $ENV{DANCER_APPDIR} = '/Users/franck/tmp/app2';
         load_app "app2";
-        Dancer::App->set_running_app('app2');
         setting appdir => '/Users/franck/tmp/app2';
+        Dancer::App->set_running_app('app2');
         Dancer::Config->load;
         my $request = Dancer::Request->new( env => $env );
         Dancer->dance($request);


### PR DESCRIPTION
Setting the appdir must come before set_running_app() or config.yml will
not be loaded.
