### PR TITLE
Update 'before' hook doco

### DIFF
--- a/lib/Dancer.pm
+++ b/lib/Dancer.pm
@@ -925,17 +925,17 @@ This hook receives as argument a L<Dancer::Error> object.
 
 =item before
 
-This is an alias to C<before>.
+This hook receives one argument, a reference to the subroutine that
+implements the route that is being intercepted by this hook.
 
-This hook receives no arguments.
-
-  before sub {
+  hook before => sub {
+    my $route_handler = shift;
     ...
   };
 
-is equivalent to
+it is equivalent to the deprecated
 
-  hook before => sub {
+  before sub {
     ...
   };
 


### PR DESCRIPTION
- BUGFIX: document that the hook gets a sub-ref argument
  commit 03665072c2660ea79b0eb2d58dd57ba398b149ef seems
  to have got lost somewhere
- clarify that a naked 'before' is deprecated
