### PR TITLE
Pr/log serialization sorting

### DIFF
--- a/lib/Dancer/Logger.pm
+++ b/lib/Dancer/Logger.pm
@@ -25,6 +25,7 @@ sub _serialize {
                         ->Terse(1)
                         ->Purity(1)
                         ->Indent(0)
+                        ->Sortkeys(1)
                         ->Dump()    :
             $_
     } @vars;

--- a/t/11_logger/08_serialize.t
+++ b/t/11_logger/08_serialize.t
@@ -7,7 +7,7 @@ use Test::More import => ['!pass'];
 plan skip_all => "Test::Output is needed for this test"
     unless Dancer::ModuleLoader->load('Test::Output');
 
-plan tests => 3;
+plan tests => 4;
 
 use Dancer ':syntax';
 set logger => 'Console';
@@ -30,3 +30,8 @@ Test::Output::stderr_like(
     'Multiple arguments are okay',
 );
 
+Test::Output::stderr_like(
+    sub { Dancer::Logger::warning( { b => 1, a => 2, e => 3, d => 4, c => 5}) }, 
+    qr/\[\d+\]  warn @.+> {'a' => 2,'b' => 1,'c' => 5,'d' => 4,'e' => 3}/,
+    'Hash keys are sorted okay',
+);


### PR DESCRIPTION
This tiny patch is almost a no-op (I didn't even note it in the CHANGERS). It calls ->Sortkeys(1) when serializing references for the logs. This allows me to have this:

```
info { b => 1, a => 2, e => 3, d => 4, c => 5};
```

And have it show up like this in the logs:

```
{'a' => 2,'b' => 1,'c' => 5,'d' => 4,'e' => 3}
```

When dealing with complicated data structures (or in my case, when cheating with my tests), it makes it easier to find the data you are looking for.
