### PR TITLE
fixed forwarded_for_address

### DIFF
--- a/lib/Dancer/Request.pm
+++ b/lib/Dancer/Request.pm
@@ -50,7 +50,7 @@ sub new {
 # aliases
 sub agent                 { $_[0]->user_agent }
 sub remote_address        { $_[0]->address }
-sub forwarded_for_address { $_[0]->env->{'X_FORWARDED_FOR'} }
+sub forwarded_for_address { $_[0]->env->{'X_FORWARDED_FOR'} || $_[0]->env->{'HTTP_X_FORWARDED_FOR'} }
 sub address               { $_[0]->env->{REMOTE_ADDR} }
 sub host {
     if (@_==2) {


### PR DESCRIPTION
IP can be in HTTP_X_FORWARDED_FOR instead of X_FORWARDED_FOR. By the way the 'address' should automatically use 'forwarded_for_address' if proxy_pass is set, should'nt it?
