### PR TITLE
Include PID in "session_dir" name so tests won't conflict when run in parallel.

### DIFF
--- a/t/08_session/05_yaml.t
+++ b/t/08_session/05_yaml.t
@@ -19,9 +19,10 @@ BEGIN {
     use_ok 'Dancer::Session::YAML'
 }
 
-
 my $dir = File::Temp::tempdir(CLEANUP => 1, TMPDIR => 1);
 set appdir => $dir;
+my $session_dir = path($dir, "sessions_$$");
+set session_dir => $session_dir;
 
 my $session = Dancer::Session::YAML->create();
 isa_ok $session, 'Dancer::Session::YAML';
@@ -50,7 +51,6 @@ $s->destroy;
 $session = Dancer::Session::YAML->retrieve($id);
 is $session, undef, 'session is destroyed';
 
-my $session_dir = "$dir/sessions";
 ok( -d $session_dir, "session dir was created");
 rmtree($session_dir);
 eval { $session = Dancer::Session::YAML->create() };

--- a/t/08_session/07_session_expires.t
+++ b/t/08_session/07_session_expires.t
@@ -30,6 +30,8 @@ my %tests = (
     "+36h"      => 'Tue, 12-Apr-2011 12:58:26 GMT',
 );
 
+my $session_dir = path( Dancer::Config::settings->{appdir}, "sessions_$$" );
+set session_dir => $session_dir;
 for my $session_expires (keys %tests) {
     my $cookie_expires = $tests{$session_expires};
 
@@ -69,5 +71,4 @@ for my $session_expires (keys %tests) {
 }
 
 # clean up after ourselves
-rmtree( path( Dancer::Config::settings->{'appdir'}, 'sessions' ) );
-
+rmtree($session_dir);

--- a/t/08_session/13_session_httponly.t
+++ b/t/08_session/13_session_httponly.t
@@ -18,13 +18,16 @@ use LWP::UserAgent;
 use File::Path 'rmtree';
 use Dancer::Config;
 
+my $session_dir = path( Dancer::Config::settings->{appdir}, "sessions_$$" );
+set session_dir => $session_dir;
+
 for my $setting ("default", "on", "off") {
     Test::TCP::test_tcp(
         client => sub {
             my $port = shift;
             my $ua   = LWP::UserAgent->new;
             my $req =
-              HTTP::Request->new(GET => "http://127.0.0.1:$port/set_session/test");
+              HTTP::Request->new(GET => "http://127.0.0.1:$port/set_session/test_13");
             my $res = $ua->request($req);
             ok $res->is_success, 'req is success';
             my $cookie = $res->header('Set-Cookie');
@@ -62,5 +65,5 @@ for my $setting ("default", "on", "off") {
 }
 
 # clean up after ourselves
-rmtree( path( Dancer::Config::settings->{'appdir'}, 'sessions' ) );
+rmtree($session_dir);
 


### PR DESCRIPTION
Fixes issue #769. Three tests were creating and clobbering a session directory of the same name, causing test failures when using the HARNESS_OPTIONS environment variable to run tests in parallel.
