### PR TITLE
Clone settings etc into template params.

### DIFF
--- a/lib/Dancer/Template/Abstract.pm
+++ b/lib/Dancer/Template/Abstract.pm
@@ -3,6 +3,7 @@ package Dancer::Template::Abstract;
 use strict;
 use warnings;
 use Carp;
+use Clone;
 
 use Dancer::Logger;
 use Dancer::Factory::Hook;
@@ -145,18 +146,18 @@ sub _prepare_tokens_options {
     $tokens ||= {};
     $tokens->{perl_version}   = $];
     $tokens->{dancer_version} = $Dancer::VERSION;
-    $tokens->{settings}       = Dancer::Config->settings;
+    $tokens->{settings}       = Clone::clone(Dancer::Config->settings);
 
     # If we're processing a request, also add the request object, params and
     # vars as tokens:
     if (my $request = Dancer::SharedData->request) {
         $tokens->{request}        = $request;
-        $tokens->{params}         = $request->params;
-        $tokens->{vars}           = Dancer::SharedData->vars;
+        $tokens->{params}         = Clone::clone($request->params);
+        $tokens->{vars}           = Clone::clone(Dancer::SharedData->vars);
     }
 
     Dancer::App->current->setting('session')
-      and $tokens->{session} = Dancer::Session->get;
+      and $tokens->{session} = Clone::clone(Dancer::Session->get);
 
     return ($tokens, $options);
 }


### PR DESCRIPTION
This should fix an interesting bug reported on the mailing list:

http://www.backup-manager.org/pipermail/dancer-users/2012-April/002424.html

Basically, we stored the settings hashref from Dancer::Config->settings into the
template params, for convenient access to the settings from the template.

This was good, except if you use [Dancer::Plugin::EscapeHTML](http://p3rl.org/Dancer::Plugin::EscapeHTML)
with the `automatic_escaping` option set, in which case, it walks through the
template params just before they're given to the template, HTML-encoding
stuff... including walking through the app's settings, as they're passed by
reference.

Cloning should solve this issue.

I haven't tested this carefully yet, but all our tests still pass with this change at least.
