### PR TITLE
Dancer::Config now reports why it could not load YAML.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@
     [ ENHANCEMENTS ]
     * Added 'info' log level for messages that should always go to the logs
       but aren't really debug, warning or error messages (Ovid)
+    * If YAML does not load, Dancer::Config now reports why (Ovid)
 
 1.3094      31.03.2012
 

--- a/lib/Dancer/Config.pm
+++ b/lib/Dancer/Config.pm
@@ -169,8 +169,10 @@ sub load {
     return 1 unless -f conffile;
 
     # load YAML
-    confess "Configuration file found but YAML is not installed"
-      unless Dancer::ModuleLoader->load('YAML');
+    my ( $result, $error ) = Dancer::ModuleLoader->load('YAML');
+    if ( not $result ) {
+        confess "Configuration file found but could not load YAML: $error";
+    }
 
     if (!$_LOADED{conffile()}) {
         load_settings_from_yaml(conffile);

--- a/t/01_config/yaml_dependency.t
+++ b/t/01_config/yaml_dependency.t
@@ -15,10 +15,10 @@ mock 'Dancer::Config'
 
 mock 'Dancer::ModuleLoader'
     => method 'load'
-    => should sub { 0 };
+    => should sub { 0, "Fish error. Goldfish in YAML." };
 
 eval { Dancer::Config->load };
-like $@, qr/Configuration file found but YAML is not installed/,
+like $@, qr/Configuration file found but could not load YAML: Fish error. Goldfish in YAML./,
     "Dancer::Config cannot load without YAML";
 
 mock 'YAML'


### PR DESCRIPTION
Previously, if YAML could not load, it was reported that YAML was not present.
This change reports the actual error.

I'm debugging a nasty issue whereby YAML is present, but it cannot load. I do not yet know why, but Dancer::Config was not reporting the actual YAML load problem. This patch fixes that.

Side note: if anyone recognizes the following :)

```
Undefined subroutine &main::main:: called at /home/cpoe/perl5/perlbrew/perls/perl-5.12.2/lib/site_perl/5.12.2/YAML/Mo.pm line 5.
```

Cheers,
Ovid`
