### PR TITLE
update ubic service example

### DIFF
--- a/lib/Dancer/Deployment.pod
+++ b/lib/Dancer/Deployment.pod
@@ -270,20 +270,13 @@ the following examples:
 
 =head4 Using Ubic
 
-L<Ubic> is an extensible perlish service manager. You can use it to start and
+L<Ubic> is a polymorphic service manager. You can use it to start and
 stop any services, automatically start them on reboots or daemon failures, and
 implement custom status checks.
 
 A basic PSGI service description (usually in /etc/ubic/service/application):
 
     use parent qw(Ubic::Service::Plack);
-
-    # if your application is not installed in @INC path:
-    sub start {
-        my $self = shift;
-        $ENV{PERL5LIB} = '/path/to/your/application/lib';
-        $self->SUPER::start(@_);
-    }
 
     __PACKAGE__->new(
         server => 'Starman',


### PR DESCRIPTION
There are two changes:
1)
There was PERL5LIB hack in old example. I removed it, since it looks like Dancer adds $app_path/lib to @INC itself.
If there are some nuances I don't know about, I can add it back, but use new `'env' => { PERL5LIB => ... }` constructor parameter instead of overloading `start` method.

2)
I call Ubic "polymorphic" now instead of "extensible perlish" :)
