### PR TITLE
Problem in Session.pm, when write key name 'id' to session like session 'id'=>'test', it rewrite session->id and everything what is writed to session after that call is saved to this new session. But in cookie is still old automaticaly generated id. When 

### DIFF
--- a/lib/Dancer/Session.pm
+++ b/lib/Dancer/Session.pm
@@ -49,6 +49,7 @@ sub read {
 sub write {
     my ($class, $key, $value) = @_;
     return unless $key;
+    die "Can't store to session key with name 'id'" if ($key eq 'id');
     my $session = get_current_session();
     $session->{$key} = $value;
 


### PR DESCRIPTION
Signed-off-by: kocoureasy igor.bujna@post.cz
