### PR TITLE
Fix flushing and delete keys in Session

### DIFF
--- a/lib/Dancer/Renderer.pm
+++ b/lib/Dancer/Renderer.pm
@@ -18,6 +18,7 @@ use Dancer::SharedData;
 use Dancer::Logger;
 use Dancer::MIME;
 use Dancer::Exception qw(:all);
+use Dancer::Session;
 
 Dancer::Factory::Hook->instance->install_hooks(
     qw/before after before_serializer after_serializer before_file_render after_file_render/
@@ -28,6 +29,16 @@ sub render_file { get_file_response() }
 sub render_action {
     my $class = shift;
     my $resp = $class->get_action_response();
+
+    # Check if session was used at all 
+    if (defined(&Dancer::Session::get_session_handle))	{
+        # If session used, flushing at now
+        my $session = &Dancer::Session::get();
+        $session->flush() if ($session);
+        # Frees session handle
+        &Dancer::Session::set_session_handle(undef);
+    }
+
     return (defined $resp)
       ? response_with_headers()
       : undef;


### PR DESCRIPTION
This patch make this 2 things:
1) can delete key from session via 'session "key" => undef'. Why we save to session keys with values which can't be used? This can delete 'key' from session. 
2) For now session in every writing key call "flush" which for eample in YAML save actual session to file. If I have this test for session:

for (my $i = 0; $i < 100000; $i++) {
    session "t_$i" => join(",", ("a".."z"));
}

For now, after every call session(session->write) it call flush and write to YAML, which can slow operation in Dancer.

I make patch which call session->flush in 'lib/Dancer/Renderer.pm' after 'render_action'. I must make handle with stored actualed given readed session, because every called  session->retrieve_current_session() retrieve new session readed from cookie and can overwrites everything stored in session. If I delete session->flush from session->write you can see problem at this test:

print STDERR session "test" . "\n"; # Print nothing
session "test" => "1"; # Storing to session
print STDERR session "test" . "\n"; # Print nothing, but must print '1'

Signed-off-by: kocoureasy igor.bujna@post.cz
