### PR TITLE
Session domain

### DIFF
--- a/lib/Dancer/Session/Abstract.pm
+++ b/lib/Dancer/Session/Abstract.pm
@@ -91,6 +91,7 @@ sub write_session_id {
     my %cookie = (
         name   => $name,
         value  => $id,
+        domain => setting('session_domain'),
         secure => setting('session_secure'),
         http_only => defined(setting("session_is_http_only")) ?
                      setting("session_is_http_only") : 1,
@@ -165,6 +166,13 @@ These settings control how a session acts.
 The default session name is "dancer_session". This can be set in your config file:
 
     setting session_name: "mydancer_session"
+
+=head3 session_domain
+
+    Allows you to set the domain property on the cookie, which will
+    override the default.  This is useful for setting the session cookie's
+    domain to something like '.domain.com' so that the same cookie will
+    be applicable and usable across subdomains of a base domain.
 
 =head3 session_secure
 

--- a/t/08_session/14_session_domain.t
+++ b/t/08_session/14_session_domain.t
@@ -1,0 +1,34 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Dancer ':syntax', ':tests';
+use Dancer::Session::Simple;
+use Test::More tests => 2;
+
+
+my $Session_Name = Dancer::Session::Simple->session_name;
+
+note "session_domain off"; {
+    set session => "simple";
+    session foo => "bar";
+
+    my $session_cookie = Dancer::Cookies->cookies->{ $Session_Name };
+    ok !$session_cookie->domain;
+}
+
+
+note "session_domain on"; {
+    delete Dancer::Cookies->cookies->{ $Session_Name };
+
+    my $test_domain = '.test-domain.com';
+
+    set session         => "simple";
+    set session_domain  => $test_domain;
+
+    session up => "down";
+
+    my $session_cookie = Dancer::Cookies->cookies->{ $Session_Name };
+    is $session_cookie->domain => $test_domain;
+}


### PR DESCRIPTION
This parameter allows you to set the domain
of the default session cookie, and is useful
for creating cookies that can span multiple
subdomains of a base domain by setting
session_domain to something like '.domain.com'.
