### PR TITLE
Removing docs for mounting multiple apps.

### DIFF
--- a/lib/Dancer/Deployment.pod
+++ b/lib/Dancer/Deployment.pod
@@ -164,49 +164,6 @@ before and after enabling this middleware. Among other things, you should
 notice that the response is gzip or deflate encoded, and contains a header
 C<Content-Encoding> set to C<gzip> or C<deflate>
 
-=head3 Running multiple apps with Plack::Builder
-
-You can use Plack::Builder to mount multiple Dancer applications on
-a L<PSGI> webserver like L<Starman>.
-
-Start by creating a simple app.psgi file:
-
-    use Dancer ':syntax';
-    use Plack::Builder;
-
-    setting apphandler => 'PSGI';
-
-    my $app1 = sub {
-        my $env = shift;
-        local $ENV{DANCER_APPDIR} = '/Users/franck/tmp/app1';
-        setting appdir => '/Users/franck/tmp/app1';
-        load_app "app1";
-        Dancer::App->set_running_app('app1');
-        Dancer::Config->load;
-        my $request = Dancer::Request->new( env => $env );
-        Dancer->dance($request);
-    };
-
-    my $app2 = sub {
-        my $env = shift;
-        local $ENV{DANCER_APPDIR} = '/Users/franck/tmp/app2';
-        setting appdir => '/Users/franck/tmp/app2';
-        load_app "app2";
-        Dancer::App->set_running_app('app2');
-        Dancer::Config->load;
-        my $request = Dancer::Request->new( env => $env );
-        Dancer->dance($request);
-    };
-
-    builder {
-        mount "/app1" => builder {$app1};
-        mount "/app2" => builder {$app2};
-    };
-
-and now use L<Starman>
-
-    plackup -a app.psgi -s Starman
-
 =head3 Hosting on DotCloud
 
 The simplest way to achieve this is to push your main application directory


### PR DESCRIPTION
Mounting multiple Dancer apps via Plack::Builder is broken, has always
been broken, and will not be fixed in the near future. We should not
encourage this approach by documenting it.
