### PR TITLE
Fixed Images over FastCGI

### DIFF
--- a/script/dancer
+++ b/script/dancer
@@ -585,7 +585,7 @@ margin: 0;
 margin-bottom: 25px;
 padding: 0;
 background-color: #ddd;
-background-image: url("/images/perldancer-bg.jpg");
+background-image: url("../images/perldancer-bg.jpg");
 background-repeat: no-repeat;
 background-position: top left;
 
@@ -635,7 +635,7 @@ padding-right: 30px;
 
 
 #header {
-background-image: url("/images/perldancer.jpg");
+background-image: url("../images/perldancer.jpg");
 background-repeat: no-repeat;
 background-position: top left;
 height: 64px;


### PR DESCRIPTION
Under FastCGI you may use a subdirectory. When you use a subdirectory
there is no image displayed. It's because "/" in stylesheets won't
work for every installation. So I changed it to "../".
