### PR TITLE
Fix initialization of %callbacks within _send_file

### DIFF
--- a/lib/Dancer.pm
+++ b/lib/Dancer.pm
@@ -408,7 +408,7 @@ sub _send_file {
             my ( $status, $headers ) = @_;
             my %callbacks = defined $options{'callbacks'} ?
                             %{ $options{'callbacks'} }    :
-                            {};
+                            ();
 
             return sub {
                 my $respond = shift;


### PR DESCRIPTION
Fixed a very minor bug within _send_file.  When using streaming and not setting any callbacks, the %callbacks hash is initialized with {} instead of ().  This causes a "Reference found where even-sized list expected" warning.
