### PR TITLE
fix Makefile.PL so that it installs wallflower

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,7 +25,7 @@ WriteMakefile1(
     ABSTRACT     => "A minimal-effort oriented web application framework",
     LICENSE      => 'perl',
     VERSION_FROM => 'lib/Dancer.pm',
-    EXE_FILES    => ['script/dancer'],
+    EXE_FILES    => ['script/dancer', 'script/wallflower'],
 
     META_MERGE => {
         resources => {


### PR DESCRIPTION
`scripts/wallflower` is bundled with the distribution, but is not
installed by Makefile.PL.  it seems a shame not to install it.
