### PR TITLE
Should config require modules in all setters?

### DIFF
--- a/lib/Dancer/Config.pm
+++ b/lib/Dancer/Config.pm
@@ -28,17 +28,21 @@ sub settings {$SETTINGS}
 my $setters = {
     logger => sub {
         my ($setting, $value) = @_;
+        require Dancer::Logger;
         Dancer::Logger->init($value, settings());
     },
     log_file => sub {
+        require Dancer::Logger;
         Dancer::Logger->init(setting("logger"), setting());
     },
     session => sub {
         my ($setting, $value) = @_;
+        require Dancer::Session;
         Dancer::Session->init($value, settings());
     },
     template => sub {
         my ($setting, $value) = @_;
+        require Dancer::Template;
         Dancer::Template->init($value, settings());
     },
     route_cache => sub {


### PR DESCRIPTION
In Dancer::Config, some of the values in $setters require their "base" modules, while others don't:

Serializer:

```
serializer => sub {
    my ($setting, $value) = @_;
    require Dancer::Serializer;
    Dancer::Serializer->init($value);
},
```

Session:

```
session => sub {
    my ($setting, $value) = @_;
    Dancer::Session->init($value, settings());
},
```

Normally the problem is masked because something else includes Dancer.pm which includes all these modules. I only noticed this when working on a maintenance script (that runs outside the the web stack but uses Dancer::Config).

Shouldn't session (and the others that are missing it) also have a require statement? It seems like having a require here is appropriate. Is there a reason some have requires while others do not?
