### PR TITLE
Escape ">" character properly inside code text in Dancer::Exception's POD

### DIFF
--- a/lib/Dancer/Exception.pm
+++ b/lib/Dancer/Exception.pm
@@ -243,7 +243,7 @@ This registers a new custom exception. To use it, do:
 
   raise InvalidCredentials => "user Herbert not found";
 
-The exception message can be retrieved with the C<$exception->message> method, and we'll be
+The exception message can be retrieved with the C<$exception-E<gt>message> method, and we'll be
 C<"invalid credentials : user Herbert not found"> (see methods in L<Dancer::Exception::Base>)
 
   # complex exception


### PR DESCRIPTION
Just a little fix so that  C<$exception-E<gt>message> is displayed properly.
