### PR TITLE
execute_hooks was singularized on Dancer 2

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,8 +1,11 @@
 {{$NEXT}}
 
+    [ ENHANCEMENTS ]
     * New keyword 'plugin_args' exported by Dancer::Plugin to provide
       a consistent way with Dancer 2 to obtain arguments from a plugin
       keyword. (Alberto Simões).
+    * Add an alias 'execute_hook' to 'execute_hooks' for homogeneity
+      with Dancer 2.
 
 1.3097      08.07.2012
 

--- a/lib/Dancer/Plugin.pm
+++ b/lib/Dancer/Plugin.pm
@@ -19,6 +19,7 @@ use vars qw(@EXPORT);
   plugin_setting
   register_hook
   execute_hooks
+  execute_hook
   plugin_args
 );
 
@@ -42,6 +43,10 @@ sub register_hook {
 }
 
 sub execute_hooks {
+    Dancer::Factory::Hook->instance->execute_hooks(@_);
+}
+
+sub execute_hook {
     Dancer::Factory::Hook->instance->execute_hooks(@_);
 }
 


### PR DESCRIPTION
We made `execute_hooks` a singular `execute_hook`.
Given Dancer 1 is already out, I added an alias.
If you prefer to delete `execute_hooks` I can do it as well.
