### PR TITLE
Add log_ compat methods

### DIFF
--- a/lib/Dancer/Plugin.pm
+++ b/lib/Dancer/Plugin.pm
@@ -29,11 +29,11 @@ use vars qw(@EXPORT);
   log_error
 );
 
-sub log_core(&)    { Dancer::Logger::core->($_[0]->())    }
-sub log_debug(&)   { Dancer::Logger::debug->($_[0]->())   }
-sub log_info(&)    { Dancer::Logger::info->($_[0]->())    }
-sub log_warning(&) { Dancer::Logger::warning->($_[0]->()) }
-sub log_error(&)   { Dancer::Logger::error->($_[0]->())   }
+sub log_core(&@)    { Dancer::Logger::core->(   shift->(@_)); @_ }
+sub log_debug(&@)   { Dancer::Logger::debug->(  shift->(@_)); @_ }
+sub log_info(&@)    { Dancer::Logger::info->(   shift->(@_)); @_ }
+sub log_warning(&@) { Dancer::Logger::warning->(shift->(@_)); @_ }
+sub log_error(&@)   { Dancer::Logger::error->(  shift->(@_)); @_ }
 
 sub register($&);
 

--- a/lib/Dancer/Plugin.pm
+++ b/lib/Dancer/Plugin.pm
@@ -21,7 +21,19 @@ use vars qw(@EXPORT);
   execute_hooks
   execute_hook
   plugin_args
+
+  log_core
+  log_debug
+  log_info
+  log_warning
+  log_error
 );
+
+sub log_core(&)    { Dancer::Logger::core->($_[0]->())    }
+sub log_debug(&)   { Dancer::Logger::debug->($_[0]->())   }
+sub log_info(&)    { Dancer::Logger::info->($_[0]->())    }
+sub log_warning(&) { Dancer::Logger::warning->($_[0]->()) }
+sub log_error(&)   { Dancer::Logger::error->($_[0]->())   }
 
 sub register($&);
 


### PR DESCRIPTION
One (final?) step towards easy universal plugins (working with both versions of dancer) would be an universal way of logging.

One problem with Dancer 2 logging is the use of ``log`` keyword, as I already pointed sometimes.

Matt Trout defends the use of Log::Contextual and it seems that some other are tempted as well (@xsawyerx at least, if I am not mistaken).

The few I could learn for some minutes looking to Log::Contextual, it works with ``log_$level`` and a subroutine reference. With that in mind, I wrote five methods in ``Dancer::Plugin`` to solve that.

If you all think this might work, I'll merge this, and work on integrating Log::Contextual on Dancer 2.

Feedback is welcome (@sukria, @dams, @bigpresh, @franckcuny, Matt...)