### PR TITLE
fix for issue #755, HTTP::Headers accepted by dancer_response

### DIFF
--- a/lib/Dancer/Test.pm
+++ b/lib/Dancer/Test.pm
@@ -353,17 +353,25 @@ Content-Type: text/plain
 
     my ($params, $body, $headers) = @$args{qw(params body headers)};
 
-    if ($headers and (my @headers = @$headers)) {
+    my $headers_obj;
+    if ($headers  && _isa($headers, 'HTTP::Headers')){
+        $headers_obj = $headers;
+        if ($headers->header('Content_Type')) {
+            $ENV{'CONTENT_TYPE'} = $headers->remove_header('Content_Type');
+        }
+    }
+    elsif ($headers and (my @headers = @$headers)) {
         while (my $h = shift @headers) {
             if ($h =~ /content-type/i) {
                 $ENV{'CONTENT_TYPE'} = shift @headers;
             }
         }
+        $headers_obj = HTTP::Headers->new(@$headers);
     }
 
     my $request = Dancer::Request->new_for_request(
         $method => $path,
-        $params, $body, HTTP::Headers->new(@$headers)
+        $params, $body, $headers_obj
     );
 
     # first, reset the current state

--- a/t/12_response/09_headers_to_array.t
+++ b/t/12_response/09_headers_to_array.t
@@ -1,7 +1,7 @@
 package main;
 use strict;
 use warnings;
-use Test::More tests => 1, import => ['!pass'];
+use Test::More tests => 3, import => ['!pass'];
 
 {
 
@@ -17,5 +17,16 @@ use Dancer::Test;
 
 response_headers_include [GET => '/'] =>
   [ 'Content-Type' => 'text/html', 'A' => 1, 'A' => 2, 'B' => 3 ];
+
+# Dancer::Test::dancer_response does accept an HTTP::Headers object now (issue 755)
+use HTTP::Headers;
+
+my $res1 = dancer_response(GET => '/', { headers => HTTP::Headers->new('Content-Type' => 'text/ascii', 'XY' => 'Z')});
+is($res1->header('Content-Type'), 'text/html', "Content-Type looks good for dancer_response accepting HTTP::Headers");
+
+my $res2 = dancer_response(GET => '/', { headers => ['Content-Type' => 'text/ascii', 'XY' => 'Z']});
+
+is_deeply($res1->headers_to_array, $res2->headers_to_array, "Headers look good for dancer_response accepting HTTP::Headers");
+
 
 1;


### PR DESCRIPTION
Dancer::Test::dancer_response should accept an HTTP::Headers object (issue 755)
