### PR TITLE
Fix Github URLs to https://

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -29,8 +29,8 @@ WriteMakefile1(
 
     META_MERGE => {
         resources => {
-            repository => 'http://github.com/sukria/Dancer',
-            bugtracker => 'http://github.com/sukria/Dancer/issues',
+            repository => 'https://github.com/sukria/Dancer',
+            bugtracker => 'https://github.com/sukria/Dancer/issues',
             homepage   => 'http://perldancer.org/',
         },
     },

--- a/lib/Dancer.pm
+++ b/lib/Dancer.pm
@@ -1865,8 +1865,9 @@ see the AUTHORS file that comes with this distribution for details.
 =head1 SOURCE CODE
 
 The source code for this module is hosted on GitHub
-L<http://github.com/sukria/Dancer>.  Feel free to fork the repository and submit
-pull requests!  (See L<Dancer::Development> for details on how to contribute).
+L<https://github.com/sukria/Dancer>.  Feel free to fork the repository and
+submit pull requests!  (See L<Dancer::Development> for details on how to
+contribute).
 
 Also, why not L<watch the repo|https://github.com/sukria/Dancer/toggle_watch> to
 keep up to date with the latest upcoming changes?

--- a/lib/Dancer/Development.pod
+++ b/lib/Dancer/Development.pod
@@ -100,12 +100,12 @@ A good way to help the project is to find a failing build log on the CPAN
 testers: L<http://www.cpantesters.org/distro/D/Dancer.html>
 
 If you find a failing test report, feel free to report it as a GitHub issue:
-L<http://github.com/sukria/Dancer/issues>.
+L<https://github.com/sukria/Dancer/issues>.
 
 =head2 Reporting Bugs
 
 We prefer to have all our bug reports on GitHub, in the issues section:
-L<http://github.com/sukria/Dancer/issues>. It's possible though to report bugs
+L<https://github.com/sukria/Dancer/issues>. It's possible though to report bugs
 on RT as well: L<https://rt.cpan.org/Dist/Display.html?Queue=Dancer>
 
 Please make sure the bug you're reporting does not yet exist. In doubt please
@@ -130,7 +130,7 @@ Here is the workflow for submitting a patch:
 
 =item *
 
-Fork the repository L<http://github.com/sukria/Dancer> (click "Fork")
+Fork the repository L<https://github.com/sukria/Dancer> (click "Fork")
 
 =item *
 
@@ -258,7 +258,7 @@ from users and contributors.
 =head2 Repositories
 
 The official repository is hosted on GitHub at the following location:
-L<http://github.com/sukria/Dancer>.
+L<https://github.com/sukria/Dancer>.
 
 Official developers have write access to this repository, contributors are
 invited to fork it if they want to submit patches, as explained in the

--- a/lib/Dancer/HTTP.pm
+++ b/lib/Dancer/HTTP.pm
@@ -123,7 +123,7 @@ This module has been written by Alexis Sukrieh <sukria@cpan.org>
 =head1 SOURCE CODE
 
 The source code for this module is hosted on GitHub
-L<http://github.com/sukria/Dancer>
+L<https://github.com/sukria/Dancer>
 
 =head1 LICENSE
 

--- a/lib/Dancer/Tutorial.pod
+++ b/lib/Dancer/Tutorial.pod
@@ -29,8 +29,8 @@ or L<Bottle|http://bottle.paws.de/docs/dev/index.html> I enjoyed the way they ex
 which was a little more involved that a trivial example.
 
 Using the
-L<Flaskr|http://github.com/mitsuhiko/flask/tree/master/examples/flaskr/> sample
-application as my inspiration (OK, shamelessly plagiarised) I
+L<Flaskr|https://github.com/mitsuhiko/flask/tree/master/examples/flaskr/>
+sample application as my inspiration (OK, shamelessly plagiarised) I
 translated that application to the Dancer framework so I could better understand how Dancer worked. (I'm learning
 it too!)
 
@@ -481,7 +481,7 @@ http://perldancer.org
 
 =item *
 
-http://github.com/sukria/Dancer
+https://github.com/sukria/Dancer
 
 =item * 
 

--- a/script/dancer
+++ b/script/dancer
@@ -363,7 +363,7 @@ WriteMakefile(
 
               <li><a href="http://perldancer.org/">PerlDancer</a></li>
               <li><a href="http://twitter.com/PerlDancer/">Official Twitter</a></li>
-              <li><a href="http://github.com/sukria/Dancer/">GitHub Community</a></li>
+              <li><a href="https://github.com/sukria/Dancer/">GitHub Community</a></li>
             </ul>
           </li>
           

--- a/t/15_plugins/03_namespace.t
+++ b/t/15_plugins/03_namespace.t
@@ -1,5 +1,5 @@
 # issue #72
-# http://github.com/sukria/Dancer/issues#issue/72
+# https://github.com/sukria/Dancer/issues#issue/72
 
 use Test::More tests => 2, import => ['!pass'];
 


### PR DESCRIPTION
Github is https only, so avoid a useless redirect in our links.

Note: This is a kind of followup to [my post about HTTPS-Everywhere](http://blogs.perl.org/users/olivier_mengue_dolmen/2012/09/https-everywhere-rulesets-for-perl-sites.html), my quest to secure Perl authors.
