### PR TITLE
provide empty headers object if not defined

### DIFF
--- a/lib/Dancer/Request.pm
+++ b/lib/Dancer/Request.pm
@@ -152,7 +152,7 @@ sub new_for_request {
     $req->_build_params();
     $req->{_query_params} = $req->{params};
     $req->{body}          = $body    if defined $body;
-    $req->{headers}       = $headers if $headers;
+    $req->{headers}       = $headers || HTTP::Headers->new;
 
     return $req;
 }


### PR DESCRIPTION
The absence of $self->{headers} makes any call to $req->header('foo')
break hard. This is at least breaking the test cases of
D::P::Cache::CHI

There might be more diligence to do on that one. I just saw that D::P::Cache::CHI is failing on the new(ish) release of Dancer and had to find out why. I'll probably follow-up on this later this week.
