### PR TITLE
Fix pesky "Use of uninitialized value $version..." message when loading plugins.

### DIFF
--- a/lib/Dancer/Handler/Standalone.pm
+++ b/lib/Dancer/Handler/Standalone.pm
@@ -53,9 +53,12 @@ sub print_startup_info {
     foreach my $module ( grep { $_ =~ m{^Dancer/Plugin/} } keys %INC ) {
         $module =~ s{/}{::}g;  # change / to ::
         $module =~ s{\.pm$}{}; # remove .pm at the end
-
         my $version = $module->VERSION;
-        print ">> $module ($version)\n";
+        if (defined $version) {
+            print ">> $module ($version)\n";
+        } else {
+            print ">> $module (no version number defined)\n";
+        }
     }
 
 }


### PR DESCRIPTION
Appears when plugins without a $VERSION are loaded by
Dancer::Handler::Standalone.  Replaced with a "no version number defined"
message.
