### PR TITLE
serve autopages with text/html content-type

### DIFF
--- a/lib/Dancer/Config.pm
+++ b/lib/Dancer/Config.pm
@@ -626,6 +626,9 @@ Dancer will honor your C<before_template_render> code, and all default
 variables. They will be accessible and interpolated on automatic
 served pages.
 
+The pages served this way will have C<Content-Type> set to C<text/html>,
+so don't use the feature for anything else.
+
 =head2 DANCER_CONFDIR and DANCER_ENVDIR
 
 It's possible to set the configuration directory and environment directory using this two

--- a/lib/Dancer/Renderer.pm
+++ b/lib/Dancer/Renderer.pm
@@ -185,6 +185,7 @@ sub _autopage_response {
     $response->content(
         Dancer::template($viewpath)
     );
+    $response->header( 'Content-Type' => 'text/html' );
     return $response;
 }
 


### PR DESCRIPTION
Pages generated with autopages have no content-type header.

Given the limited use of this feature, it was suggested that the simplest solution was probably the best, and that setting a default of text/html was a good first stab at a solution.
