### PR TITLE
_read_to_end: check definedness instead of value

### DIFF
--- a/lib/Dancer/Request.pm
+++ b/lib/Dancer/Request.pm
@@ -495,7 +495,8 @@ sub _read_to_end {
     return unless $self->_has_something_to_read();
 
     if ($content_length > 0) {
-        while (my $buffer = $self->_read()) {
+        my $buffer;
+        while (defined ($buffer = $self->_read())) {
             $self->{body} .= $buffer;
             $self->{_http_body}->add($buffer);
         }


### PR DESCRIPTION
Check whether the buffer returned by _read() is defined instead of
evaluating it for truth.

The old behavior caused a body consisting only of "0" to disappear; this
commit fixes the problem.
