### PR TITLE
Fix Bug #844/#760 - Misleading plack middleware documentation

### DIFF
--- a/lib/Dancer/Cookbook.pod
+++ b/lib/Dancer/Cookbook.pod
@@ -868,14 +868,14 @@ To enable middlewares in Dancer, you just have to set the plack_middlewares
 setting like the following:
 
     set plack_middlewares => [
-        [ 'SomeMiddleware' => [ qw(some options for somemiddleware) ]],
+        [ 'SomeMiddleware' => qw(some options for somemiddleware) ],
     ];
 
 For instance, if you want to enable L<Plack::Middleware::Debug> in your Dancer
 application, all you have to do is to set C<plack_middlewares> like that:
 
     set plack_middlewares => [
-        [ 'Debug' => [ 'panels' => [qw(DBITrace Memory Timer)] ] ],
+        [ 'Debug' => ( 'panels' => [qw(DBITrace Memory Timer)] ) ],
     ];
 
 Of course, you can also put this configuration into your config.yml file, or
@@ -886,12 +886,11 @@ even in your environment configuration files:
     plack_middlewares:
       -
         - Debug          # first element of the array is the name of the middleware
+        - panels         # following elements are the configuration ofthe middleware
         -
-            - panels         # following elements are the configuration ofthe middleware
-            -
-              - DBITrace
-              - Memory
-              - Timer
+            - DBITrace
+            - Memory
+            - Timer
 
 =head3 Path-based middlewares
 


### PR DESCRIPTION
The Plack middlware interface expects an array of arrays, where
the first element of each one is the middleware name, and the rest
are the arguments to that middleware.  The Cookbook suggests a
name and array-reference is required.

This change adjusts the data structures used appropriately (both
in code and in YAML).

Tested against Dancer 1.3095 and Plack 0.9988
