### PR TITLE
Correct example apache config

### DIFF
--- a/lib/Dancer/Deployment.pod
+++ b/lib/Dancer/Deployment.pod
@@ -471,7 +471,7 @@ following:
         ServerAlias myapp.example.com
         DocumentRoot /websites/myapp.example.com
 
-        <Directory /home/myapp/myapp>
+        <Directory /websites/myapp.example.com>
             AllowOverride None
             Order allow,deny
             Allow from all


### PR DESCRIPTION
Changed the Directory block value to match the DocumentRoot value, which I think was probably the original intention as there is no other reference to <tt>/home/myapp/myapp</tt> in the example.
