### PR TITLE
ignore non-HASH request bodies

### DIFF
--- a/lib/Dancer/Serializer.pm
+++ b/lib/Dancer/Serializer.pm
@@ -100,6 +100,10 @@ sub process_request {
         return $request;
     }
 
+    if(!ref $new_params or ref $new_params ne 'HASH'){
+        return $request;
+    }
+
     (keys %$old_params)
       ? $request->_set_body_params({%$old_params, %$new_params})
       : $request->_set_body_params($new_params);


### PR DESCRIPTION
Generally, request bodies are mixed into the `params` HASH.  This
works great except when the request body doesn't deserialize to a
HASH.

This change short-circuits this process and leaves the request body
as is so that it can be deserialized later in the request cycle if
desired.
