### PR TITLE
Marking import_warnings deprecated

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -54,6 +54,7 @@ A huge thank you to all of them!
     Joshua Barratt <jbarratt@serialized.net>
     Juan J. Martínez <reidrac@usebox.net>
     Jury Gorky <schwein@schwein-laptop.(none)>
+    Kaitlyn Parkhurst <symkat@symkat.com>
     Marc Chantreux <marc.chantreux@biblibre.com>
     Mark Allen <mrallen1@yahoo.com>
     Mark Stosberg <mark@stosberg.com>

--- a/lib/Dancer/Config.pm
+++ b/lib/Dancer/Config.pm
@@ -55,10 +55,14 @@ my $setters = {
         require Dancer::Serializer;
         Dancer::Serializer->init($value);
     },
-    # This should be deprecated, and is kept
-    # for backwards compatiblity.
+    # This setting has been deprecated in favor of global_warnings.
     import_warnings => sub {
         my ($setting, $value) = @_;
+
+         Dancer::Deprecation->deprecated(
+             message => "import_warnings has been deprecated, please use global_warnings instead."
+         );
+
         $^W = $value ? 1 : 0;
     },
     global_warnings => sub {


### PR DESCRIPTION
As suggested by yanick, import_warnings is marked as
deprecated and will emit a warning on its use.

I've added myself as a contributor to the author file for work on
https://github.com/PerlDancer/Dancer/commit/9aee1c73365b876b7110253e6363a5f7a5078c02
