### PR TITLE
Non-numerical ge warnings from generated Makefile.PL

### DIFF
--- a/script/dancer
+++ b/script/dancer
@@ -323,12 +323,17 @@ sub templates($) {
 use warnings;
 use ExtUtils::MakeMaker;
 
+# Normalize version strings like 6.30_02 to 6.3002,
+# so that we can do numerical comparisons on it.
+my \$eumm_version = \$ExtUtils::MakeMaker::VERSION;
+\$eumm_version =~ s/_//;
+
 WriteMakefile(
     NAME                => '$appname',
     AUTHOR              => q{YOUR NAME <youremail\@example.com>},
     VERSION_FROM        => 'lib/$appfile.pm',
     ABSTRACT            => 'YOUR APPLICATION ABSTRACT',
-    (\$ExtUtils::MakeMaker::VERSION >= 6.3001
+    (\$eumm_version >= 6.3001
       ? ('LICENSE'=> 'perl')
       : ()),
     PL_FILES            => {},


### PR DESCRIPTION
ExtUtils::MakeMaker often has versions of the following format: '6.30_02'. Doing numerical comparisons on strings like this, as done in the script/dancer generated Makefile.PL, yields a warning:

```
Argument "6.57_05" isn't numeric in numeric ge (>=) at Makefile.PL line 5.
```

(Debian Unstable currently has 6.57_05.)

As a nitpick, I also changed the minimum version of EUMM to 6.30_01, as the LICENSE field was introduced at that release. I'm sure this shouldn't affect anybody, but it made it easier for me to correlate the comparison with the EUMM changelog. (Was there a reason why 6.30_02 was chosen over 6.30_01?)

Also, I'm well aware that my solution is quite ugly. You'd probably have better ideas on how to solve it.

Regards,
/Olof
