### PR TITLE
skip tests of deprecated features except when releasing

### DIFF
--- a/t/00_base/17_globalwarnings_config_on.t
+++ b/t/00_base/17_globalwarnings_config_on.t
@@ -10,10 +10,14 @@ is $^W, 1, "Global warnings turned on through global_warnings";
 set global_warnings => 0;
 is $^W, 0, "Global warnings turned off through global_warnings";
 
-set import_warnings => 1;
-is $^W, 1, "Global warnings turned on through import_warnings";
+#
+SKIP: {
+    skip 'config setting \'import_warnings\' has been deprecated', 2 unless ($ENV{RELEASE_TESTING});
 
-set import_warnings => 0;
-is $^W, 0, "Global warnings turned off through import_warnings";
+    set import_warnings => 1;
+    is $^W, 1, "Global warnings turned on through import_warnings";
 
+    set import_warnings => 0;
+    is $^W, 0, "Global warnings turned off through import_warnings";
+}
 done_testing();


### PR DESCRIPTION
It seems normal install doesn't necessarily need to test deprecated features. It leads to ugly test warnings.
