### PR TITLE
FIX: to_dumper to accept and pass all along whole argument array

### DIFF
--- a/lib/Dancer/Serializer/Dumper.pm
+++ b/lib/Dancer/Serializer/Dumper.pm
@@ -14,16 +14,16 @@ sub from_dumper {
 }
 
 sub to_dumper {
-    my ($data) = @_;
+    my (@data) = @_;
     my $s = Dancer::Serializer::Dumper->new;
-    $s->serialize($data);
+    $s->serialize(\@data);
 }
 
 sub serialize {
     my ($self, $entity) = @_;
     {
         local $Data::Dumper::Purity = 1;
-        return Dumper($entity);
+        return Dumper(@$entity);
     }
 }
 


### PR DESCRIPTION
FIX: to_dumper to accept and pass all along whole argument array, not only first entry. Same behaviour as Data::Dumper(). May brake compatibility.

Current results when called to_dumper(qw(a b c)):

```
$VAR1 = 'a';
```

Expected result (as Data::Dumper):

```
$VAR1 = 'a';
$VAR2 = 'b';
$VAR3 = 'c';
```
