### PR TITLE
Make messages from fatal warnings show up in the logs

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -316,6 +316,7 @@ t/24_deployment/01_multi_webapp.t
 t/25_exceptions/01_exceptions.t
 t/25_exceptions/02_exceptions.t
 t/25_exceptions/03_exceptions.t
+t/25_exceptions/04_exceptions_warn.t
 t/25_exceptions/views/error.tt
 t/25_exceptions/views/index.tt
 t/25_exceptions/views/layouts/main.tt

--- a/lib/Dancer/Route.pm
+++ b/lib/Dancer/Route.pm
@@ -259,14 +259,11 @@ sub execute {
     if (Dancer::Config::setting('warnings')) {
         my $warning;
         my $content = do {
-            local $SIG{__WARN__} = sub { $warning = $_[0] };
+            local $SIG{__WARN__} = sub { $warning ||= $_[0] };
             $self->code->();
         };
         if ($warning) {
-            return Dancer::Error->new(
-                code    => 500,
-                message => "Warning caught during route execution: $warning",
-            )->render;
+            die "Warning caught during route execution: $warning";
         }
         return $content;
     }

--- a/t/25_exceptions/04_exceptions_warn.t
+++ b/t/25_exceptions/04_exceptions_warn.t
@@ -1,0 +1,41 @@
+use strict;
+use warnings;
+use Test::More import => ['!pass'];
+
+use Dancer::Logger::File;
+use Dancer ':syntax';
+use Dancer::Test;
+use Dancer::Exception ':all';
+
+plan skip_all => "File::Temp 0.22 required"
+    unless Dancer::ModuleLoader->load( 'File::Temp', '0.22' );
+
+my $dir = File::Temp::tempdir(CLEANUP => 1, TMPDIR => 1);
+my $logfile= "$dir/logs/test.log";
+
+set warnings => 1; # we want to test fatal warnings
+set log => 'fatal';
+set logger => 'null'; # we'll monkeypatch later
+set views => path( 't', '25_exceptions', 'views' );
+
+use vars qw(@log_messages);
+
+{
+    no warnings 'redefine';
+    local *Dancer::Logger::Null::_log = sub { shift; push @log_messages, $_[1] };
+    # raise a (now fatal) warning in the route handler
+    get '/raise_in_hook' => sub {
+        warn "Boom";
+        template 'index', { foo => 'baz5' };
+    };
+    route_exists [ GET => '/raise_in_hook' ];
+    response_status_is( [ GET => '/raise_in_hook' ], 500 => "Internal error due to warning");
+    response_content_like( [ GET => '/raise_in_hook' ], qr|Error 500| );
+    
+    # Now, check that we find the error in the log
+    my @error= grep {m!request to GET /raise_in_hook crashed!} @log_messages;
+    is 0+@error, 2, "We logged the fatal warning to the logger (two calls)";
+}
+
+done_testing();
+


### PR DESCRIPTION
When running with the `warnings => 1` setting (as is the
default for the development config), these fatal warnings
cause an Error 500 to be returned but do not show up in
the logger at all. This is less than helpful.

This patch changes it so that the warnings show up in the
logger.
