### PR TITLE
Handles the case when logging format wants header, but no request exists

### DIFF
--- a/lib/Dancer/Logger/Abstract.pm
+++ b/lib/Dancer/Logger/Abstract.pm
@@ -77,6 +77,7 @@ sub format_message {
             return "[" . strftime( $block, localtime ) . "]";
         }
         elsif ( $type eq 'h' ) {
+            return '-' unless defined $r;
             return scalar $r->header($block) || '-';
         }
         else {


### PR DESCRIPTION
This is an important patch for us because our logger format contains `h` for getting a header value in each of our log lines. For our `:script` scripts, there is no request, so our scripts blow up when we do any logging in them. This patch makes logging headers more robust by first checking if a request exists.
