### PR TITLE
need latest Test::TCP

### DIFF
--- a/t/00_base/12_utf8_charset.t
+++ b/t/00_base/12_utf8_charset.t
@@ -9,7 +9,7 @@ use LWP::UserAgent;
 
 plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
 plan skip_all => "Test::TCP is needed for this test"
-    unless Dancer::ModuleLoader->load("Test::TCP" => '1.13');
+    unless Dancer::ModuleLoader->load("Test::TCP" => '1.30');
 
 plan tests => 4;
 

--- a/t/02_request/07_raw_data.t
+++ b/t/02_request/07_raw_data.t
@@ -8,7 +8,7 @@ use lib File::Spec->catdir( 't', 'lib' );
 
 plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
 plan skip_all => "Test::TCP is needed for this test"
-    unless Dancer::ModuleLoader->load("Test::TCP" => "1.13");
+    unless Dancer::ModuleLoader->load("Test::TCP" => "1.30");
 
 use LWP::UserAgent;
 

--- a/t/02_request/10_mixed_params.t
+++ b/t/02_request/10_mixed_params.t
@@ -9,7 +9,7 @@ use lib File::Spec->catdir( 't', 'lib' );
 
 plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
 plan skip_all => "Test::TCP is needed for this test"
-    unless Dancer::ModuleLoader->load("Test::TCP" => "1.13");
+    unless Dancer::ModuleLoader->load("Test::TCP" => "1.30");
 
 use LWP::UserAgent;
 

--- a/t/02_request/13_ajax.t
+++ b/t/02_request/13_ajax.t
@@ -4,7 +4,7 @@ use warnings;
 
 plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
 plan skip_all => 'Test::TCP is needed to run this test'
-    unless Dancer::ModuleLoader->load('Test::TCP' => "1.13");
+    unless Dancer::ModuleLoader->load('Test::TCP' => "1.30");
 plan tests => 8;
 
 use LWP::UserAgent;

--- a/t/02_request/15_headers.t
+++ b/t/02_request/15_headers.t
@@ -4,7 +4,7 @@ use warnings;
 
 plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
 plan skip_all => 'Test::TCP is needed to run this test'
-    unless Dancer::ModuleLoader->load('Test::TCP' => "1.13");
+    unless Dancer::ModuleLoader->load('Test::TCP' => "1.30");
 
 use LWP::UserAgent;
 

--- a/t/03_route_handler/21_ajax.t
+++ b/t/03_route_handler/21_ajax.t
@@ -6,7 +6,7 @@ use Dancer::Test;
 
 plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
 plan skip_all => 'Test::TCP is needed to run this test'
-    unless Dancer::ModuleLoader->load('Test::TCP' => "1.13");
+    unless Dancer::ModuleLoader->load('Test::TCP' => "1.30");
 
 use LWP::UserAgent;
 

--- a/t/03_route_handler/28_plack_mount.t
+++ b/t/03_route_handler/28_plack_mount.t
@@ -6,7 +6,7 @@ BEGIN {
     use Dancer::ModuleLoader;
     plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
     plan skip_all => "Test::TCP is needed to run this test"
-      unless Dancer::ModuleLoader->load('Test::TCP' => "1.13");
+      unless Dancer::ModuleLoader->load('Test::TCP' => "1.30");
     plan skip_all => "Plack is needed to run this test"
       unless Dancer::ModuleLoader->load('Plack::Builder');
 }

--- a/t/03_route_handler/33_vars.t
+++ b/t/03_route_handler/33_vars.t
@@ -9,7 +9,7 @@ use LWP::UserAgent;
 
 plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
 plan skip_all => "Test::TCP is needed for this test"
-    unless Dancer::ModuleLoader->load("Test::TCP" => "1.13");
+    unless Dancer::ModuleLoader->load("Test::TCP" => "1.30");
 
 plan tests => 10;
 Test::TCP::test_tcp(

--- a/t/03_route_handler/34_forward_body_post.t
+++ b/t/03_route_handler/34_forward_body_post.t
@@ -11,7 +11,7 @@ BEGIN {
     plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
 
     plan skip_all => 'Test::TCP is needed to run this test'
-        unless Dancer::ModuleLoader->load('Test::TCP' => "1.13");
+        unless Dancer::ModuleLoader->load('Test::TCP' => "1.30");
 }
 
 use Dancer;

--- a/t/04_static_file/001_base.t
+++ b/t/04_static_file/001_base.t
@@ -14,7 +14,7 @@ plan skip_all => "Skip test with Test::TCP in win32"
   if $^O eq 'MSWin32';
     
 plan skip_all => "Test::TCP is required"
-  unless Dancer::ModuleLoader->load('Test::TCP' => "1.13");
+  unless Dancer::ModuleLoader->load('Test::TCP' => "1.30");
 
 plan skip_all => "Plack is required"
   unless Dancer::ModuleLoader->load('Plack::Loader');

--- a/t/07_apphandlers/03_psgi_app.t
+++ b/t/07_apphandlers/03_psgi_app.t
@@ -5,7 +5,7 @@ use Dancer::ModuleLoader;
 
 plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
 plan skip_all => "Test::TCP is needed to run this test"
-    unless Dancer::ModuleLoader->load('Test::TCP' => "1.13");
+    unless Dancer::ModuleLoader->load('Test::TCP' => "1.30");
 plan skip_all => "Plack is needed to run this test"
     unless Dancer::ModuleLoader->load('Plack::Request');
 

--- a/t/07_apphandlers/04_standalone_app.t
+++ b/t/07_apphandlers/04_standalone_app.t
@@ -5,7 +5,7 @@ use Dancer::ModuleLoader;
 
 plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
 plan skip_all => "Test::TCP is needed for this test"
-    unless Dancer::ModuleLoader->load("Test::TCP" => "1.13");
+    unless Dancer::ModuleLoader->load("Test::TCP" => "1.30");
 plan skip_all => "Test::TCP is needed for this test"
     unless Dancer::ModuleLoader->load("Plack::Loader");
 

--- a/t/07_apphandlers/05_middlewares.t
+++ b/t/07_apphandlers/05_middlewares.t
@@ -11,7 +11,7 @@ use lib File::Spec->catdir( 't', 'lib' );
 
 plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
 plan skip_all => "Test::TCP is needed for this test"
-  unless Dancer::ModuleLoader->load("Test::TCP" => "1.13");
+  unless Dancer::ModuleLoader->load("Test::TCP" => "1.30");
 plan skip_all => "Plack is needed to run this test"
   unless Dancer::ModuleLoader->load('Plack::Request');
 

--- a/t/07_apphandlers/07_middleware_map.t
+++ b/t/07_apphandlers/07_middleware_map.t
@@ -11,7 +11,7 @@ use lib File::Spec->catdir('t','lib');
 
 plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
 plan skip_all => "Test::TCP is needed for this test"
-  unless Dancer::ModuleLoader->load("Test::TCP" => "1.13");
+  unless Dancer::ModuleLoader->load("Test::TCP" => "1.30");
 plan skip_all => "Plack is needed to run this test"
   unless Dancer::ModuleLoader->load('Plack::Request');
 

--- a/t/08_session/03_http_requests.t
+++ b/t/08_session/03_http_requests.t
@@ -8,7 +8,7 @@ BEGIN {
     plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
 
     plan skip_all => 'Test::TCP is needed to run this test'
-        unless Dancer::ModuleLoader->load('Test::TCP' => "1.13");
+        unless Dancer::ModuleLoader->load('Test::TCP' => "1.30");
     plan skip_all => 'YAML is needed to run this test'
         unless Dancer::ModuleLoader->load('YAML');
     plan skip_all => "File::Temp 0.22 required"

--- a/t/08_session/07_session_expires.t
+++ b/t/08_session/07_session_expires.t
@@ -15,7 +15,7 @@ use Dancer::Cookie;
 
 plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
 plan skip_all => "Test::TCP is needed for this test"
-  unless Dancer::ModuleLoader->load("Test::TCP" => "1.13");
+  unless Dancer::ModuleLoader->load("Test::TCP" => "1.30");
 plan skip_all => "YAML is needed for this test"
   unless Dancer::ModuleLoader->load("YAML");
 

--- a/t/08_session/13_session_httponly.t
+++ b/t/08_session/13_session_httponly.t
@@ -8,7 +8,7 @@ use Dancer::Cookie;
 
 plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
 plan skip_all => "Test::TCP is needed for this test"
-  unless Dancer::ModuleLoader->load("Test::TCP" => "1.13");
+  unless Dancer::ModuleLoader->load("Test::TCP" => "1.30");
 plan skip_all => "YAML is needed for this test"
   unless Dancer::ModuleLoader->load("YAML");
 

--- a/t/09_cookies/03_persistence.t
+++ b/t/09_cookies/03_persistence.t
@@ -7,7 +7,7 @@ BEGIN {
 
     plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
     plan skip_all => 'Test::TCP is needed to run this test'
-        unless Dancer::ModuleLoader->load('Test::TCP' => "1.13");
+        unless Dancer::ModuleLoader->load('Test::TCP' => "1.30");
     plan skip_all => "File::Temp 0.22 required"
         unless Dancer::ModuleLoader->load( 'File::Temp', '0.22' );
 };

--- a/t/12_response/04_charset_server.t
+++ b/t/12_response/04_charset_server.t
@@ -10,7 +10,7 @@ my $min_hh = 5.827;
 
 plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
 plan skip_all => "Test::TCP is needed for this test"
-    unless Dancer::ModuleLoader->load("Test::TCP" => "1.13");
+    unless Dancer::ModuleLoader->load("Test::TCP" => "1.30");
 
 plan skip_all => "HTTP::Headers $min_hh required (use of content_type_charset)"
     unless Dancer::ModuleLoader->load( 'HTTP::Headers', $min_hh );

--- a/t/12_response/08_drop_content.t
+++ b/t/12_response/08_drop_content.t
@@ -7,7 +7,7 @@ BEGIN {
     use Dancer::ModuleLoader;
     plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
     plan skip_all => 'Test::TCP is needed to run this test'
-      unless Dancer::ModuleLoader->load('Test::TCP' => "1.13");
+      unless Dancer::ModuleLoader->load('Test::TCP' => "1.30");
 }
 
 plan tests => 4;

--- a/t/14_serializer/17_clear_serializer.t
+++ b/t/14_serializer/17_clear_serializer.t
@@ -6,7 +6,7 @@ use LWP::UserAgent;
 
 plan skip_all => "skip test with Test::TCP in win32" if  $^O eq 'MSWin32';
 plan skip_all => 'Test::TCP is needed to run this test'
-    unless Dancer::ModuleLoader->load('Test::TCP' => "1.13");
+    unless Dancer::ModuleLoader->load('Test::TCP' => "1.30");
 
 plan skip_all => 'JSON is needed to run this test'
     unless Dancer::ModuleLoader->load('JSON');

--- a/t/15_plugins/07_ajax_plack_builder.t
+++ b/t/15_plugins/07_ajax_plack_builder.t
@@ -8,7 +8,7 @@ BEGIN {
     use Dancer::ModuleLoader;
     plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
     plan skip_all => "Test::TCP is needed to run this test"
-      unless Dancer::ModuleLoader->load('Test::TCP' => "1.13");
+      unless Dancer::ModuleLoader->load('Test::TCP' => "1.30");
     plan skip_all => "Plack is needed to run this test"
       unless Dancer::ModuleLoader->load('Plack::Builder');
 }

--- a/t/21_dependents/Dancer-Session-Cookie.t
+++ b/t/21_dependents/Dancer-Session-Cookie.t
@@ -11,7 +11,7 @@ plan skip_all => "Dancer::Session::Cookie 0.14 required"
 
 plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
 plan skip_all => "Test::TCP required"
-    unless Dancer::ModuleLoader->load('Test::TCP' => "1.13");
+    unless Dancer::ModuleLoader->load('Test::TCP' => "1.30");
 Test::TCP->import;
 
 plan skip_all => "HTTP::Cookies required"

--- a/t/24_deployment/01_multi_webapp.t
+++ b/t/24_deployment/01_multi_webapp.t
@@ -6,7 +6,7 @@ BEGIN {
     use Dancer::ModuleLoader;
     plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
     plan skip_all => "Test::TCP is needed to run this test"
-      unless Dancer::ModuleLoader->load('Test::TCP' => "1.13");
+      unless Dancer::ModuleLoader->load('Test::TCP' => "1.30");
     plan skip_all => "Plack is needed to run this test"
       unless Dancer::ModuleLoader->load('Plack::Builder');
 }


### PR DESCRIPTION
as per the discussion on the dev-dancer list. one of the later versions of Test::TCP is crankign up the setting rate, which makes tests fail because ports are not available.
