### PR TITLE
Add require_environment setting.

### DIFF
--- a/lib/Dancer/Config.pm
+++ b/lib/Dancer/Config.pm
@@ -202,6 +202,10 @@ sub load {
         load_settings_from_yaml($env);
         $_LOADED{$env}++;
     }
+    elsif (setting('require_environment')) {
+        # failed to load the env file, and the main config said we needed it.
+        confess "Could not load environment file '$env', and require_environment is set";
+    }
 
     foreach my $key (grep { $setters->{$_} } keys %$SETTINGS) {
         $setters->{$key}->($key, $SETTINGS->{$key});
@@ -466,6 +470,13 @@ If set to true, tells Dancer to consider all warnings as blocking errors.
 
 If set to true, Dancer will display full stack traces when a warning or a die
 occurs. (Internally sets Carp::Verbose). Default to false.
+
+=head3 require_environment (boolean)
+
+If set to true, Dancer will fail during startup if your environment file is
+missing or can't be read. This is especially useful in production when you
+have things like memcached settings that need to be set per-environment.
+Default to false.
 
 =head3 server_tokens (boolean)
 

--- a/t/01_config/08_environments.t
+++ b/t/01_config/08_environments.t
@@ -6,7 +6,7 @@ use Dancer::ModuleLoader;
 Dancer::ModuleLoader->load('YAML')
     or plan skip_all => 'YAML is needed to run this test';
 
-plan tests => 5;
+plan tests => 7;
 
 use File::Spec;
 use Dancer ':syntax';
@@ -47,4 +47,13 @@ ok -f $path;
 
 ok(Dancer::Config->load, 'load prod environment');
 is(setting('log'), 'warning', 'log setting looks good');
+
+# see what happens when envfile is required but not present
+setting('require_environment' => 1);
+setting('environment' => 'missing');
+# expect it to fail with a confess()
+eval { Dancer::Config->load };
+ok($@, 'dies if environment required but missing');
+like($@, qr/missing\.yml/, '... error message includes environment file name');
+
 File::Temp::cleanup();


### PR DESCRIPTION
This branch adds a single new config setting to force the environment file to be present and readable. If set to true, Dancer will fail during startup if your environment file is missing or can't be read. This is especially useful in production when you have things like memcached settings that need to be set per-environment. It also helps catch typos in the environment file, and helps avoid production from running with the default 'development' environment settings.  I thought about building this as a plugin, but it's actually a very small amount of code and I think it makes more sense as part of the core.

I've tried to match style and naming conventions, but please let me know if you want it cleaned up at all. 
