### PR TITLE
Enable Unicode log output to console

### DIFF
--- a/lib/Dancer/Logger/Console.pm
+++ b/lib/Dancer/Logger/Console.pm
@@ -3,6 +3,8 @@ use strict;
 use warnings;
 use base 'Dancer::Logger::Abstract';
 
+binmode(STDERR, ':utf8');
+
 sub _log {
     my ($self, $level, $message) = @_;
     print STDERR $self->format_message($level => $message);


### PR DESCRIPTION
When logging a character such as "™" to the console, the following error is produced:

```
[28211] error @0.011815> [hit #1]request to GET /foo crashed: Warning caught during route execution: Wide character in print at .../perl5/lib/perl5/Dancer/Logger/Console.
pm line 9
```

Example:

``` perl
get '/foo' => sub {
    debug "testing™";
    return bar;
};
```
