### PR TITLE
json Utf8 behavior

### DIFF
--- a/lib/Dancer.pm
+++ b/lib/Dancer.pm
@@ -827,6 +827,11 @@ Deserializes a JSON structure. Can receive optional arguments. Those arguments
 are valid L<JSON> arguments to change the behaviour of the default
 C<JSON::from_json> function.
 
+If no explicit I<utf8>
+argument is passed, it'll default to C<true>, making the function
+behave like I<decode_json>.
+
+
 =head2 from_yaml ($structure)
 
 Deserializes a YAML structure.
@@ -1766,6 +1771,10 @@ Serializes a structure with Data::Dumper.
 Serializes a structure to JSON. Can receive optional arguments. Thoses arguments
 are valid L<JSON> arguments to change the behaviour of the default
 C<JSON::to_json> function.
+
+If no explicit I<utf8>
+argument is passed, it'll default to C<true>, making the serialization
+behave like I<encode_json>.
 
 =head2 to_yaml ($structure)
 

--- a/lib/Dancer/Serializer/JSON.pm
+++ b/lib/Dancer/Serializer/JSON.pm
@@ -62,21 +62,19 @@ sub deserialize {
     JSON::from_json( $entity, $options );
 }
 
-# Standard JSON behaviour is fine when serializing; we'll end up
-# encoding as UTF8 later on.
 sub _serialize_options_as_hashref {
     my $self = shift;
     my $options = $self->_options_as_hashref(@_) || {};
-    $options->{utf8} = 1 if !exists $options->{utf8};
+    # by default, behave like encode_json
+    $options->{utf8} = 1 unless exists $options->{utf8};
     return $options;
 }
 
-# JSON should be UTF8 by default, so explicitly decode it as such
-# on its way in.
 sub _deserialize_options_as_hashref {
     my $self = shift;
     my $options = $self->_options_as_hashref(@_) || {};
-    $options->{utf8} = 1 if !exists $options->{utf8};
+    # by default, behave like decode_json
+    $options->{utf8} = 1 unless exists $options->{utf8};
     return $options;
 }
 
@@ -124,7 +122,7 @@ This can be done in your config.yml file or directly in your app code with the
 B<set> keyword. This serializer will also be used when the serializer is set
 to B<mutable> and the correct Accept headers are supplied.
 
-The L<JSON> module will pass configuration variables straight through.
+The L<JSON> module will pass configuration variables straight through. 
 Some of these can be useful when debugging/developing your app: B<pretty> and
 B<canonical>, and others useful with ORMs like L<DBIx::Class>: B<allow_blessed>
 and B<convert_blessed>.  Please consult the L<JSON> documentation for more
@@ -142,11 +140,19 @@ settings to the B<engines> configuration to turn these on. For example:
 
 =head2 serialize
 
-Serialize a data structure to a JSON structure.
+Serialize a data structure to a JSON structure. 
+
+If no explicit I<utf8>
+option is passed, it'll default to C<true>, making the serialization
+behave like I<encode_json>.
 
 =head2 deserialize
 
-Deserialize a JSON structure to a data structure
+Deserialize a JSON structure to a data structure.
+
+If no explicit I<utf8>
+option is passed, it'll default to C<true>, making the deserialization
+behave like I<decode_json>.
 
 =head2 content_type
 

--- a/lib/Dancer/Serializer/JSON.pm
+++ b/lib/Dancer/Serializer/JSON.pm
@@ -65,7 +65,10 @@ sub deserialize {
 # Standard JSON behaviour is fine when serializing; we'll end up
 # encoding as UTF8 later on.
 sub _serialize_options_as_hashref {
-    return shift->_options_as_hashref(@_);
+    my $self = shift;
+    my $options = $self->_options_as_hashref(@_) || {};
+    $options->{utf8} = 1 if !exists $options->{utf8};
+    return $options;
 }
 
 # JSON should be UTF8 by default, so explicitly decode it as such

--- a/t/14_serializer/19_json_utf8.t
+++ b/t/14_serializer/19_json_utf8.t
@@ -1,0 +1,16 @@
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+
+use utf8;
+use Dancer::Serializer::JSON;
+
+my $data = { foo => 'café' };
+
+is Dancer::Serializer::JSON::from_json(
+    Dancer::Serializer::JSON::to_json( $data )
+)->{foo} => $data->{foo}, "encode/decode round-trip";
+
+
+


### PR DESCRIPTION
Coming from #771 

In a nutshell, we make Dancer's from_json behave like 'decode_json', but don't do the reverse for 'encode_json'. Hilarity ensues.

This fix document our helpful behavior, and make the from_json and to_json.

Now, I'm kinda scared of the comment that was there for 'encode_json', to the effect that the utf8 encoding would be done down the line. I still have to make due dilligences to make sure this fix doesn't inject any double-encoding bug.
