### PR TITLE
Add synopsis with simple example to Dancer::Request::Upload

### DIFF
--- a/lib/Dancer/Request/Upload.pm
+++ b/lib/Dancer/Request/Upload.pm
@@ -74,6 +74,23 @@ sub type {
 
 Dancer::Request::Upload - class representing file uploads requests
 
+=head1 SYNOPSIS
+
+    # in your view have a form
+    <form action="/upload" method="post" enctype="multipart/form-data">
+      <input type="file" name="filename">
+      <input type="submit">
+    </form>
+   
+    # and then in your application handler
+    post '/upload' => sub {
+      my $file = request->upload('filename'); 
+      $file->copy_to($upload_dir);  # or whatever you need
+    };
+
+This simple example introduces a possible usage of this module to handle
+file uploads.
+
 =head1 DESCRIPTION
 
 This class implements a representation of file uploads for Dancer.


### PR DESCRIPTION
Add synopsis to Dancer::Request::Upload to include a very basic example on this module can be used.
