### PR TITLE
Update Handler.pm

### DIFF
--- a/lib/Dancer/Handler.pm
+++ b/lib/Dancer/Handler.pm
@@ -193,7 +193,7 @@ sub render_response {
 
 sub _is_text {
     my ($content_type) = @_;
-    return $content_type =~ /(x(?:ht)?ml|text|json|javascript)/;
+    return $content_type =~ /(\bx(?:ht)?ml\b|text|json|javascript)/;
 }
 
 # Fancy banner to print on startup


### PR DESCRIPTION
I had a hard time trying to find why my Excel files of Content-type

application/vnd.openxmlformats-officedocument.spreadsheetml.sheet

(taken from http://blogs.msdn.com/b/vsofficedeveloper/archive/2008/05/08/office-2007-open-xml-mime-types.aspx )

were all corrupt.

Turns out Dancer thinks they are XML (they are zipped XML) because there is "xml" in the content-type.

A quick check on the net made me believe that real xml mime types have the string "xml" as seperate words (maybe with a "+" before it), so I think word boundaries would be good here.

At least they fixed my problem.
