### PR TITLE
Abstract out key-value store from Session engine

### DIFF
--- a/lib/Dancer/Session.pm
+++ b/lib/Dancer/Session.pm
@@ -47,7 +47,7 @@ sub read {
     my ($class, $key) = @_;
     return unless $key;
     my $session = get_current_session();
-    return $session->{$key};
+    return $session->get_value($key);
 }
 
 sub write {
@@ -57,7 +57,7 @@ sub write {
     $key eq 'id' and croak 'Can\'t store to session key with name "id"';
 
     my $session = get_current_session();
-    $session->{$key} = $value;
+    $session->set_value($key, $value);
 
     # TODO : should be moved as an "after" filter
     $session->flush unless $session->is_lazy;

--- a/lib/Dancer/Session/Abstract.pm
+++ b/lib/Dancer/Session/Abstract.pm
@@ -60,6 +60,20 @@ sub session_name {
     setting('session_name') || 'dancer.session';
 }
 
+# May be overriden if session key value pairs aren't stored in the
+# session object's hash
+sub get_value {
+    my ( $self, $key ) = @_;
+    return $self->{$key};
+}
+
+# May be overriden if session key value pairs aren't stored in the
+# session object's hash
+sub set_value {
+    my ( $self, $key, $value ) = @_;
+    $self->{$key} = $value;
+}
+
 
 # Methods below this line should not be overloaded.
 


### PR DESCRIPTION
Currently the Session singleton interface assumes that the key value pairs of the session object are stored as hash attributes in the session object. However, a specific session engine implementation may want to store these in another way. This patch abstracts the access of the key value pairs out of the Session singleton into the engine base class (Session/Abstract.pm) so that how the keys are stored can be handled differently each engine implementation.
