### PR TITLE
Fix for unwanted modification of original data while dumping

### DIFF
--- a/lib/Dancer/Error.pm
+++ b/lib/Dancer/Error.pm
@@ -118,13 +118,16 @@ sub dumper {
 
 
     # Take a copy of the data, so we can mask sensitive-looking stuff:
-    my %data     = Dancer::ModuleLoader->load('Clone') ?
-                   %{ Clone::clone($obj) }             :
-                   %$obj;
-    my $censored = _censor(\%data);
+    my $data     = Dancer::ModuleLoader->load('Clone') ?
+                   Clone::clone($obj)
+                   : eval Data::Dumper->new([$obj])->Purity(1)->Terse(1)->Deepcopy(1)->Dump;
+
+    $data = {%$data} if blessed($data); 
+
+	my $censored = _censor($data);
 
     #use Data::Dumper;
-    my $dd = Data::Dumper->new([\%data]);
+    my $dd = Data::Dumper->new([$data]);
     $dd->Terse(1)->Quotekeys(0)->Indent(1)->Sortkeys(1);
     my $content = $dd->Dump();
     $content =~ s{(\s*)(\S+)(\s*)=>}{$1<span class="key">$2</span>$3 =&gt;}g;

--- a/t/12_response/10_error_dumper.t
+++ b/t/12_response/10_error_dumper.t
@@ -5,14 +5,14 @@ use Test::More;
 use Dancer::Error;
 use Dancer::ModuleLoader;
 
-plan skip_all => 'Clone is required for this test'
-    unless Dancer::ModuleLoader->load('Clone');
-
-plan tests => 4;
+plan tests => 5;
 
 my $error_obj = Dancer::Error->new(
     code => '404',
     pass => 'secret',
+    deep => {
+        pass => 'secret'
+    },
 );
 
 isa_ok( $error_obj, 'Dancer::Error' );
@@ -21,7 +21,7 @@ my $censored = $error_obj->dumper;
 
 like(
     $censored,
-    qr/\QNote: Values of 1 sensitive-looking key hidden\E/,
+    qr/\QNote: Values of 2 sensitive-looking keys hidden\E/,
     'Data was censored in the output',
 );
 
@@ -29,6 +29,12 @@ is(
     $error_obj->{'pass'},
     'secret',
     'Original data was not overwritten',
+);
+
+is(
+    $error_obj->{'deep'}{'pass'},
+    'secret',
+    'Censoring of complex data structures works fine',
 );
 
 my %recursive;


### PR DESCRIPTION
There is a bug in the Dancer::Error::dumper function.
If you don't have Clone module installed on your system (which is neither a standard module nor a prerequisite for Dancer) then Dancer can modify the original data while "censoring" it. 

For example, if you are running under a persistent environment and your app config has something like

``` yaml
facebook:
    app_id: 123
    app_secret: abc
```

then once it is dumped (which happens automatically if your app fails for any reason and you have "show_errors" enabled) the config becomes corrupted and all subsequent requests that use that config will fail.
