### PR TITLE
skip the correct number of tests when JSON or YAML is not installed

### DIFF
--- a/t/14_serializer/06_api.t
+++ b/t/14_serializer/06_api.t
@@ -49,9 +49,9 @@ SKIP: {
 }
 
 SKIP: {
-    skip 'JSON is needed to run this test', 3
+    skip 'JSON is needed to run this test', 5
       unless Dancer::ModuleLoader->load('JSON');
-    skip 'YAML is needed to run this test', 3
+    skip 'YAML is needed to run this test', 5
       unless Dancer::ModuleLoader->load('YAML');
 
     set serializer => 'Mutable';


### PR DESCRIPTION
t/14_serializer/06_api.t was failing on my box because it was only skipping 3 tests instead of the 5 that where expected to run
