### PR TITLE
Check X-Forwarded-Proto when behind a proxy to see what the protocol is

### DIFF
--- a/lib/Dancer/Request.pm
+++ b/lib/Dancer/Request.pm
@@ -72,11 +72,11 @@ sub request_base          { $_[0]->env->{REQUEST_BASE} || $_[0]->env->{HTTP_REQU
 sub scheme                {
     my $scheme;
     if (setting('behind_proxy')) {
+        # The PSGI spec prefixes all headers with 'HTTP_'
         $scheme = $_[0]->env->{'X_FORWARDED_PROTOCOL'}
                || $_[0]->env->{'HTTP_X_FORWARDED_PROTOCOL'}
                || $_[0]->env->{'HTTP_X_FORWARDED_PROTO'}
                || $_[0]->env->{'HTTP_FORWARDED_PROTO'}
-               || $_[0]->env->{'X_FORWARDED_PROTO'}
                || ""
     }
     return $scheme

--- a/t/03_route_handler/06_redirect.t
+++ b/t/03_route_handler/06_redirect.t
@@ -77,19 +77,19 @@ plan tests => 17;
 # redirect behind proxy
 {
     set behind_proxy => 1;
-    $ENV{X_FORWARDED_HOST} = "nice.host.name";
+    $ENV{HTTP_X_FORWARDED_HOST} = "nice.host.name";
     response_headers_include [GET => '/bounce'] => [Location => 'http://nice.host.name/'],
       "Test X_FORWARDED_HOST";
 
-    local $ENV{X_FORWARDED_PROTO} = "proto";
+    $ENV{HTTP_FORWARDED_PROTO} = "https";
+    response_headers_include [GET => '/bounce'] => [Location => 'https://nice.host.name/'],
+      "Test FORWARDED_PROTO";
+
+    $ENV{HTTP_X_FORWARDED_PROTO} = "proto";
     response_headers_include [GET => '/bounce'] => [Location => 'proto://nice.host.name/'],
       "Test X_FORWARDED_PROTO";
 
-    $ENV{HTTP_FORWARDED_PROTO} = "https";
-    response_headers_include [GET => '/bounce'] => [Location => 'https://nice.host.name/'],
-      "Test HTTP_FORWARDED_PROTO";
-
-    $ENV{X_FORWARDED_PROTOCOL} = "ftp";  # stupid, but why not?
+    $ENV{HTTP_X_FORWARDED_PROTOCOL} = "ftp";  # stupid, but why not?
     response_headers_include [GET => '/bounce'] => [Location => 'ftp://nice.host.name/'],
       "Test X_FORWARDED_PROTOCOL";
 


### PR DESCRIPTION
Hey, here is a tiny change to support check X-Forwarded-Proto when behind a proxy

Both https://metacpan.org/pod/Dancer::Deployment#Using-Nginx and http://en.wikipedia.org/wiki/List_of_HTTP_header_fields#cite_ref-17 suggest this is the correct header to check but the code wasn't checking it
