### PR TITLE
Remove printing of version in ModuleLoader

### DIFF
--- a/lib/Dancer/ModuleLoader.pm
+++ b/lib/Dancer/ModuleLoader.pm
@@ -15,7 +15,6 @@ sub load {
 
 sub require {
     my ($class, $module, $version) = @_;
-    print "version $version\n" if $version;
     eval { defined $version ? use_module( $module, $version ) 
                             : use_module( $module ) } 
         or return wantarray ? (0, $@) : 0;


### PR DESCRIPTION
Conditionally printing the version here seems out of place to me.
