### PR TITLE
Default host to '-' if envs not available

### DIFF
--- a/lib/Dancer/Logger/Abstract.pm
+++ b/lib/Dancer/Logger/Abstract.pm
@@ -89,7 +89,7 @@ sub format_message {
     my $chars_mapping = {
         h => sub {
             defined $r
-              ? $r->env->{'HTTP_X_REAL_IP'} || $r->env->{'REMOTE_ADDR'}
+              ? $r->env->{'HTTP_X_REAL_IP'} || $r->env->{'REMOTE_ADDR'} || '-'
               : '-';
         },
         t => sub { Encode::decode(setting('charset') || 'utf8',


### PR DESCRIPTION
I ran into a case where I was trying to log something when the request object existed but before the request's env hash was fully populated which caused a warning ('Use of uninitialized value in substitution iterator') if the %h token was used in the logging formatting string.

This patch defaults the value to '-' (instead of a blank string) in this situation.
