### PR TITLE
check for valid cookie name

### DIFF
--- a/lib/Dancer/Cookies.pm
+++ b/lib/Dancer/Cookies.pm
@@ -37,7 +37,7 @@ sub parse_cookie_from_env {
         # cookie_name="foo=bar"
         # we want `cookie_name' as the value and `foo=bar' as the value
         my( $name, $value ) = split(/\s*=\s*/, $cookie, 2);
-        next unless ( $name );
+        next unless ( length $name );
         my @values;
         if ( defined $value && $value ne '' ) {
             @values = map { uri_unescape($_) } split( /[&;]/, $value );


### PR DESCRIPTION
We quite often observe the following warning in our logs

```
Use of uninitialized value in hash element at /usr/lib/perl5/site_perl/5.8.8/Dancer/Cookies.pm line 44
```

which is likely caused by an `$env_str` containing something like `cookie1=foo; ;cookie2=bar`.
Apart from that, `$name` would be defined but empty if `$env_str` contains something like `=foo`

Proposed change: check that cookie name in `$name` is defined and not empty
