### PR TITLE
Prevent using names of existing modules as application name for dancer script.

### DIFF
--- a/script/dancer
+++ b/script/dancer
@@ -77,6 +77,9 @@ NOYAML
 sub validate_app_name {
     my $name = shift;
 
+    die "$name is an already existing module, please pick a different name for your application.\n"
+        if grep { -f join '/', $_, $name . '.pm' } @INC;
+
     return unless $name =~ /[^\w:]/ 
                or $name =~ /^\d/ 
                or $name =~ /\b:\b|:{3,}/;


### PR DESCRIPTION
Tested patch for issue #1037.
