### PR TITLE
import_warnings in 002_strict_and_warnings.t: global_warnings?

### DIFF
--- a/t/00_base/002_strict_and_warnings.t
+++ b/t/00_base/002_strict_and_warnings.t
@@ -44,7 +44,7 @@ use Test::More tests => 10, import => ['!pass'];
 
     # check that we can enable it
     {
-        setting import_warnings => 1;
+        setting global_warnings => 1;
 
         my $warn;
         local $SIG{__WARN__} = sub { $warn = $_[0] };


### PR DESCRIPTION
use new global_warnings instead of deprecated import_warnings in test

It looks like somebody forgot to adapt this test when import_warnings was deprecated, so I tried to do that. At the very least there should be an issue on the deprecation notice. 

hope that helps
