### PR TITLE
skip utf8 test not only on win32 but also cygwin

### DIFF
--- a/t/00_base/12_utf8_charset.t
+++ b/t/00_base/12_utf8_charset.t
@@ -7,7 +7,7 @@ use Test::More import => ['!pass'];
 use Dancer::ModuleLoader;
 use LWP::UserAgent;
 
-plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
+plan skip_all => "skip test with Test::TCP in win32/cygwin" if ($^O eq 'MSWin32' or $^O eq 'cygwin');
 plan skip_all => "Test::TCP is needed for this test"
     unless Dancer::ModuleLoader->load("Test::TCP" => '1.30');
 
@@ -47,6 +47,8 @@ Test::TCP::test_tcp(
         Dancer->dance();
     },
 );
+
+print "GH!\n";
 
 sub u {
     encode('UTF-8', $_[0]);

--- a/t/02_request/07_raw_data.t
+++ b/t/02_request/07_raw_data.t
@@ -6,7 +6,7 @@ use Dancer;
 use File::Spec;
 use lib File::Spec->catdir( 't', 'lib' );
 
-plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
+plan skip_all => "skip test with Test::TCP in win32/cygwin" if ($^O eq 'MSWin32'or $^O eq 'cygwin');
 plan skip_all => "Test::TCP is needed for this test"
     unless Dancer::ModuleLoader->load("Test::TCP" => "1.30");
 

--- a/t/02_request/10_mixed_params.t
+++ b/t/02_request/10_mixed_params.t
@@ -7,7 +7,7 @@ use Dancer::ModuleLoader;
 use File::Spec;
 use lib File::Spec->catdir( 't', 'lib' );
 
-plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
+plan skip_all => "skip test with Test::TCP in win32" if ($^O eq 'MSWin32' or $^O eq 'cygwin');
 plan skip_all => "Test::TCP is needed for this test"
     unless Dancer::ModuleLoader->load("Test::TCP" => "1.30");
 


### PR DESCRIPTION
test t/00_base/12_utf8_charset.t hangs on my cygwin. Not sure why. Looks like this is expected and somebody just forgot the exception for cygwin.