### PR TITLE
Fix default test names for headers and redirection test methods

### DIFF
--- a/lib/Dancer/Test.pm
+++ b/lib/Dancer/Test.pm
@@ -253,7 +253,7 @@ sub _sort_headers {
 
 sub response_headers_include {
     my ($req, $expected, $test_name) = @_;
-    $test_name ||= "headers include expected data for @$req";
+    $test_name ||= "headers include expected data for " . _req_label($req);
     my $tb = Test::Builder->new;
 
     my $response = _req_to_response($req);
@@ -262,7 +262,7 @@ sub response_headers_include {
 
 sub response_redirect_location_is {
     my ($req, $expected, $test_name) = @_;
-    $test_name ||= "redirect location looks good for @$req";
+    $test_name ||= "redirect location looks good for " . _req_label($req);
     my $tb = Test::Builder->new;
 
     my $response = _req_to_response($req);


### PR DESCRIPTION
The default test names in `response_headers_include` and `response_redirect_location_is` assume `$req` is an array reference, so these methods fail when a `Dancer::Response` is passed and no test name is provided:

``` perl
my $resp = dancer_response GET => '/someurl';
response_headers_include $resp, [ someheader => 'somevalue' ]; # Not an ARRAY reference at ...
```

`$req` should be wrapped in `_req_label` (as it is in other test methods) -- this commit fixes that.
