### PR TITLE
Allow Dancer::Handler::Debug to get env variables

### DIFF
--- a/lib/Dancer/Handler/Debug.pm
+++ b/lib/Dancer/Handler/Debug.pm
@@ -13,7 +13,7 @@ use Dancer::SharedData;
 sub run {
     my ($self, $req) = @_;
 
-    my ($method, $path, $query) = @ARGV;
+    my ($method, $path, $query, @env ) = @ARGV;
     my $host    = "127.0.0.1";
     my $port    = "3000";
 
@@ -31,6 +31,7 @@ sub run {
         'SERVER_PROTOCOL' => 'HTTP/1.1',
         'SERVER_SOFTWARE' => 'HTTP::Server::Simple/0.41',
         'SERVER_URL'      => "http://$host:$port/",
+        map { /=/ ? split /=/, $_, 2 : () } @env
     };
 
     $req = Dancer::Request->new(env => $env);
@@ -83,8 +84,10 @@ When developing a Dancer application, it can be useful to trace precisely what
 happen when a query is processed. This handler is here to provide the developer
 with a way to easily run the dancer application with the Perl debugger.
 
-This handler will process only one query, based on the first argument given on
-the command line ($ARGV[0]).
+This handler will process only one query, based on the arguments given on
+the command line, which must follow the pattern
+
+    <verb> <path> <parameter segment> <env variable> <even variable>
 
 =head1 USAGE
 
@@ -92,7 +95,13 @@ the command line ($ARGV[0]).
     set apphandler => 'Debug';
 
     # then, run the app the following way
+    perl -d bin/app.pl GET '/some/path/to/test' 
+
+    # with arguments
     perl -d bin/app.pl GET '/some/path/to/test' 'with=parameters&other=42'
+
+    # with environment variables
+    perl -d bin/app.pl GET '/some/path/to/test' '' HTTP_X_REQUESTED_WITH=XMLHttpRequest SERVER_NAME=fake
 
 =head1 AUTHORS
 

--- a/t/07_apphandlers/06_debug.t
+++ b/t/07_apphandlers/06_debug.t
@@ -6,13 +6,14 @@ use Dancer::ModuleLoader;
 plan skip_all => "Test::Output is needed for this test"
     unless Dancer::ModuleLoader->load("Test::Output");
 
-plan tests => 3;
+plan tests => 4;
 
 use Dancer;
 
 set startup_info => false, apphandler   => 'Debug';
 
 get '/' => sub { 42 };
+get '/env' => sub { request->env->{HTTP_X_REQUESTED_WITH} };
 
 my $handler = Dancer::Handler->get_handler;
 isa_ok $handler, 'Dancer::Handler::Debug';
@@ -27,3 +28,17 @@ Test::Output::stdout_like
   );
 
 is $psgi->[0], 200, "psgi response is ok";
+
+subtest "env variables" => sub {
+    plan tests => 2;
+
+    @ARGV = (GET => '/env', 'foo=42', 'HTTP_X_REQUESTED_WITH=XMLHttpRequest');
+    Test::Output::stdout_like
+    (
+    sub { $psgi = Dancer->start },
+    qr{X-Powered-By: Perl Dancer.*XMLHttpRequest}sm, 
+    "output looks good"
+    );
+
+    is $psgi->[0], 200, "psgi response is ok";
+};


### PR DESCRIPTION
Env variables can now be specified from the command line,
which should provide a more generic solution for #1041.
