### PR TITLE
Fix a test failure when building under perl-5.8.9

### DIFF
--- a/t/15_plugins/05b_plugins_and_c3.t
+++ b/t/15_plugins/05b_plugins_and_c3.t
@@ -3,7 +3,7 @@ use warnings;
 use Test::More import => ['!pass'];
 plan tests => 3;
 
-{
+SKIP: {
     use Dancer ':syntax';
 
     # This plugin already inherits from Data::Dumper


### PR DESCRIPTION
perl-5.8.9 ships with Test::More version 1.001003 which calls "last SKIP" to exit a SKIP block.  Creating such a named block stops the tests failing under this old version of Test::More.
