### PR TITLE
Fix send_file environment variables

### DIFF
--- a/lib/Dancer.pm
+++ b/lib/Dancer.pm
@@ -367,7 +367,8 @@ sub _send_file {
     my ($path, %options) = @_;
     my $env = Dancer::SharedData->request->env;
 
-    my $request = Dancer::Request->new_for_request('GET' => $path);
+    my $request = Dancer::Request->new_for_request('GET' => $path, undef, undef,
+        undef, $env);
     Dancer::SharedData->request($request);
 
     # if you asked for streaming but it's not supported in PSGI


### PR DESCRIPTION
Some request environment variables, such as `psgi.*`, are missing when a file is served using `send_file`. I'm not sure how to write a proper test for this, but the problem can be demonstrated with a simple app:

``` perl
package testenv;
use Dancer ':syntax';

our $VERSION = '0.1';

get '/' => sub {
    template 'index';
};

get '/file' => sub {
    send_file('/etc/hostname', system_path => 1, content_type => 'text/plain');
};

hook 'after_file_render' => sub {
    debug "url_scheme: " . request->env->{'psgi.url_scheme'};
};

true;
```

A request for, say, `/images/perldancer.jpg`, produces `url_scheme: http`, while a request for `/file` results in `url_scheme:` (undefined).

This change fixes the problem by passing the `SharedData->request` environment to the new request object created in `_send_file`.
