### PR TITLE
Add check for readonly values in $config

### DIFF
--- a/lib/Dancer/Config.pm
+++ b/lib/Dancer/Config.pm
@@ -234,7 +234,7 @@ sub load_settings_from_yaml {
     while( my ($k,$v) = each %$config ) {
         my $nv = Dancer::Config->normalize_setting($k,$v);
 
-        if (readonly $config->{$k} and $v ne $v) {
+        if (readonly $config->{$k} and $v ne $nv) {
             # YAML or YAML::XS creates readonly hash keys. die if we need to
             # update but cannot.
             confess "Cannot normalize+merge config for key: $k!";


### PR DESCRIPTION
Before normalize can overwrite the value, need to check for readonly values which cannot be overwritten.
