### PR TITLE
Store ajax routes in declaration order.

### DIFF
--- a/lib/Dancer/Route/Registry.pm
+++ b/lib/Dancer/Route/Registry.pm
@@ -76,7 +76,7 @@ sub add_route {
     # get routes.
     if (keys %{$route->{options}}) {
         splice @{$self->routes($route->method)},
-               $self->{routes_boundary}{$route->method}++,
+               $self->{routes_border}{$route->method}++,
                0,
                $route;
     }

--- a/lib/Dancer/Route/Registry.pm
+++ b/lib/Dancer/Route/Registry.pm
@@ -18,7 +18,17 @@ sub init {
     unless (defined $self->{id}) {
         $self->id($id++);
     }
+
+    # Routes are stored here.  Keys are route methods, and values are
+    # arrays of routes.  Routes with options are stored in the
+    # beginning of the array while routes without options are stored
+    # at the end.
     $self->{routes} = {};
+
+    # Keep track of the border between routes with and without
+    # options, so that routes with options can be easily inserted into
+    # its routes array.
+    $self->{routes_border} = {};
 
     return $self;
 }
@@ -48,14 +58,14 @@ sub routes {
 sub add_route {
     my ($self, $route) = @_;
     $self->{routes}{$route->method} ||= [];
-    my $registered = $self->routes($route->method);
-    my $last       = $registered->[-1];
+    my @registered = @{$self->routes($route->method)};
+    my $last       = $registered[-1];
     $route->set_previous($last) if defined $last;
 
     # Routes are stored in the order they are declared. However,
-    # routes with options (such as ajax routes) should be stored
-    # before non-options/non-ajax routes. This way, we can have the
-    # following routes:
+    # routes with options (such as ajax routes) are stored before
+    # routes without options. This way, we can have the following
+    # routes:
     #
     #   get  '/'    => sub {};
     #   get  qr{.*} => sub {};
@@ -65,14 +75,13 @@ sub add_route {
     # And the user won't have to declare the ajax routes before the
     # get routes.
     if (keys %{$route->{options}}) {
-        my $index = @$registered;
-        for my $i (0..$#$registered) {
-            $index = $i, last if ! keys %{$registered->[$i]{options}};
-        }
-        splice @$registered, $index, 0, $route;
+        splice @{$self->routes($route->method)},
+               $self->{routes_boundary}{$route->method}++,
+               0,
+               $route;
     }
     else {
-        push @$registered, $route;
+        push @{$self->routes($route->method)}, $route;
     }
 
     return $route;

--- a/t/03_route_handler/21_ajax.t
+++ b/t/03_route_handler/21_ajax.t
@@ -10,7 +10,7 @@ plan skip_all => 'Test::TCP is needed to run this test'
 
 use LWP::UserAgent;
 
-plan tests => 43;
+plan tests => 58;
 
 ok(Dancer::App->current->registry->is_empty,
     "registry is empty");
@@ -33,6 +33,9 @@ Test::TCP::test_tcp(
             { path => 'layout', ajax => 0, success => 1, content => 'wibble' },
             { path => 'die', ajax => 1, success => 0 },
             { path => 'layout', ajax => 0, success => 1, content => 'wibble' },
+            { path => 'order/A', ajax => 1, success => 1, content => 'A' },
+            { path => 'order/*', ajax => 1, success => 1, content => '*' },
+            { path => 'order/Z', ajax => 1, success => 1, content => '*' },
         );
 
         foreach my $query (@queries) {
@@ -94,6 +97,15 @@ Test::TCP::test_tcp(
         };
         get '/layout' => sub {
             return setting 'layout';
+        };
+        ajax '/order/A' => sub {
+            return 'A';
+        };
+        ajax '/order/*' => sub {
+            return '*';
+        };
+        ajax '/order/Z' => sub {
+            return 'Z';
         };
         start();
     },


### PR DESCRIPTION
Ajax routes were being unshifted to the beginning of routes, causing the
last declared ajax route to be tried first.  If that last route is a
default route (ajax qr{.*} => sub ...), then none of the earlier ajax
routes will match.
