### PR TITLE
Update YAML.pm

### DIFF
--- a/lib/Dancer/Session/YAML.pm
+++ b/lib/Dancer/Session/YAML.pm
@@ -75,7 +75,13 @@ sub retrieve {
 
 sub yaml_file {
     my ($id) = @_;
-    return path(setting('session_dir'), "$id.yml");
+
+    # Untaint Session ID before using it in file actions
+    # required when running under Perl Taint mode
+    $id =~ m/^([\d]*)$/;
+    my $yaml_file = "$1.yml";
+
+    return path(setting('session_dir'), $yaml_file);
 }
 
 sub destroy {


### PR DESCRIPTION
Running Dancer under Perl taint mode resulted in an insecure dependency, owing to the Session ID being used to create a session filename without first untainting it. This change untaints the numeric session ID before returning it as a file name.