### PR TITLE
Minor doc update to detail how to pass protocol information in Apache

### DIFF
--- a/lib/Dancer/Deployment.pod
+++ b/lib/Dancer/Deployment.pod
@@ -288,6 +288,11 @@ mod_proxy and mod_proxy_http must be enabled.
     a2enmod proxy
     a2enmod proxy_http
 
+Note that Apache does not pass protocol information when proxying, so if
+needed then you will need to set it manually in your Apache config:
+
+    RequestHeader set X_FORWARDED_PROTO "https"
+
 It is also important to set permissions for proxying for security purposes,
 below is an example.
 


### PR DESCRIPTION
It appears that Apache does not forward protocol information when
proxying. This doc update details this fact and provides a workaround.

See also
http://lists.preshweb.co.uk/pipermail/dancer-users/2012-April/002416.html
