### PR TITLE
Allow mixed named params and splats in route captures

### DIFF
--- a/t/03_route_handler/04_wildcards_megasplat.t
+++ b/t/03_route_handler/04_wildcards_megasplat.t
@@ -3,7 +3,7 @@ use Test::More;
 
 use Dancer::Test;
 
-plan tests => 4;
+plan tests => 6;
 
 get '/foo/**'   => sub { show_splat() };
 response_content_is [ GET => '/foo/a/b/c' ] => '(a,b,c)';
@@ -14,6 +14,19 @@ response_content_is [ GET => '/bar/a/b/c' ] => 'a:(b,c)';
 get '/alpha/**/gamma' => sub { show_splat() };
 response_content_is [ GET => '/alpha/beta/delta/gamma' ] => '(beta,delta)';
 response_content_is [ GET => '/alpha/beta/gamma' ] => '(beta)';
+
+# mixed tokens and splat
+my $route_code = sub {
+    my $id = param 'id';
+    $id = 'undef' unless defined $id;
+    my $splt = show_splat();
+    return "$id:$splt"
+};
+get '/some/:id/**/*' => $route_code;
+response_content_is [ GET => '/some/where/to/run/and/hide' ] => 'where:(to,run,and):hide';
+
+get '/some/*/**/:id?' => $route_code;
+response_content_is [ GET => '/some/one/to/say/boo/' ] => 'undef:one:(to,say,boo)';
 
 sub show_splat {
     return join ':', map { ref $_ ? "(" . join( ',', @$_ ) . ")": $_ } splat;


### PR DESCRIPTION
Allows route definitions with mixed token (param), splat and megasplats,
such as get '/some/:id/**/*' => sub {};.

To solve param/token/splat ordering, all (compiled) captures are now
tagged with regex comments (previously only splat and megasplat were
tagged with comments). These are extracted and values iterated over
so we can assign a captured value as a token or a splat.

Closes #742.