### PR TITLE
Dancer::Config: doc: correct layout dir is $views/layouts

### DIFF
--- a/lib/Dancer/Config.pm
+++ b/lib/Dancer/Config.pm
@@ -460,7 +460,7 @@ use Template Toolkit, add the following to C<config.yml>:
 =head3 layout (string)
 
 The name of the layout to use when rendering view. Dancer will look for
-a matching template in the directory $views/layout.
+a matching template in the directory $views/layouts.
 
 Your can override the default layout using the third argument of the
 C<template> keyword. Check C<Dancer> manpage for details.


### PR DESCRIPTION
The value is defined in Dancer::Template::Abstract (in `layout()`).
