### PR TITLE
Skip tests requiring fork() when no fork() is available

### DIFF
--- a/t/04_static_file/003_mime_types_reinit.t
+++ b/t/04_static_file/003_mime_types_reinit.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 
+use Config;
 use IO::Handle;
 
 use Dancer::MIME;
@@ -8,6 +9,12 @@ use Dancer ':syntax';
 use Dancer::ModuleLoader;
 
 use Test::More import => ['!pass'];
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
 
 plan tests => 3;
 


### PR DESCRIPTION
If you build perl on Windows without -DPERL_IMPLICIT_SYS (which I do, in
order to enable -DPEL_MALLOC, which seems faster than using the system
malloc()) then you don't get the fork() emulation and one of Dancer's
tests fail.

This commit skips that test in the same manner as various other CPAN
modules do in this case. This allows a normal "cpan install ..." of
Dancer to succeed without having "force" anything.