### PR TITLE
Fix scaffolded development.yml: console logger writes to STDERR

### DIFF
--- a/bin/dancer
+++ b/bin/dancer
@@ -946,7 +946,7 @@ template: \"simple\"
 "# configuration file for development environment
 
 # the logger engine to use
-# console: log messages to STDOUT (your console where you started the
+# console: log messages to STDERR (your console where you started the
 #          application server)
 # file:    log message to a file in log/
 logger: \"console\"


### PR DESCRIPTION
The `environments/development.yml` file produced by `dancer -a` says in a comment that the console logger writes to STDOUT, but Dancer::Logger::Console clearly prints to STDERR.