### PR TITLE
Pass in correct config hash

### DIFF
--- a/lib/Dancer/Config.pm
+++ b/lib/Dancer/Config.pm
@@ -35,7 +35,7 @@ my $setters = {
     },
     log_file => sub {
         require Dancer::Logger;
-        Dancer::Logger->init(setting("logger"), setting());
+        Dancer::Logger->init(setting("logger"), settings());
     },
     session => sub {
         my ($setting, $value) = @_;


### PR DESCRIPTION
The init method expects a config object as the second parameter, so I believe this was a typo.