### PR TITLE
Removed reference to with_id logger format.

### DIFF
--- a/lib/Dancer/Logger/Abstract.pm
+++ b/lib/Dancer/Logger/Abstract.pm
@@ -231,17 +231,13 @@ header value
 
 =back
 
-There is two preset possible:
+There is currently a single preset log format:
 
 =over 4
 
 =item simple
 
-will format the message like: [%P] %L @%D> %m in %f l. %l
-
-=item with_id
-
-will format the message like: [%P] %L @%D> [hit #%i] %m in %f l. %l
+will format the message like: [%P] %L @%D> %i%m in %f l. %l
 
 =back
 


### PR DESCRIPTION
As far as I can tell this format was only referenced in the
documentation.  The request ID is (now?) part of the "simple" format.