### PR TITLE
Load settings from hash

### DIFF
--- a/lib/Dancer/Config.pm
+++ b/lib/Dancer/Config.pm
@@ -189,32 +189,34 @@ sub load {
     init_envdir();
 
     # look for the conffile
-    return 1 unless -f conffile;
+    if (-f conffile) {
 
-    # load YAML
-    my $module = $SETTINGS->{engines}{YAML}{module} || 'YAML';
+        # load YAML
+        my $module = $SETTINGS->{engines}{YAML}{module} || 'YAML';
 
-    my ( $result, $error ) = Dancer::ModuleLoader->load($module);
-    confess "Configuration file found but could not load $module: $error"
-        unless $result;
+        my ( $result, $error ) = Dancer::ModuleLoader->load($module);
+        confess "Configuration file found but could not load $module: $error"
+            unless $result;
 
-    unless ($_LOADED{conffile()}) {
-        load_settings_from_yaml(conffile);
-        $_LOADED{conffile()}++;
-    }
-
-    my $env = environment_file;
-
-    # don't load the same env twice
-    unless( $_LOADED{$env} ) {
-        if (-f $env ) {
-            load_settings_from_yaml($env);
-            $_LOADED{$env}++;
+        unless ($_LOADED{conffile()}) {
+            load_settings_from_yaml(conffile);
+            $_LOADED{conffile()}++;
         }
-        elsif (setting('require_environment')) {
-            # failed to load the env file, and the main config said we needed it.
-            confess "Could not load environment file '$env', and require_environment is set";
+
+        my $env = environment_file;
+
+        # don't load the same env twice
+        unless( $_LOADED{$env} ) {
+            if (-f $env ) {
+                load_settings_from_yaml($env);
+                $_LOADED{$env}++;
+            }
+            elsif (setting('require_environment')) {
+                # failed to load the env file, and the main config said we needed it.
+                confess "Could not load environment file '$env', and require_environment is set";
+            }
         }
+
     }
 
     if ($extra_config) {

--- a/lib/Dancer/Config.pm
+++ b/lib/Dancer/Config.pm
@@ -182,6 +182,9 @@ sub init_envdir {
 }
 
 sub load {
+
+    my (undef, $extra_config) = @_;
+
     init_confdir();
     init_envdir();
 
@@ -214,6 +217,10 @@ sub load {
         }
     }
 
+    if ($extra_config) {
+        load_settings_from_hashref($extra_config);
+    }
+
     foreach my $key (grep { $setters->{$_} } keys %$SETTINGS) {
         $setters->{$key}->($key, $SETTINGS->{$key});
     }
@@ -222,6 +229,20 @@ sub load {
     }
 
     return 1;
+}
+
+sub load_settings_from_hashref {
+    my ($config) = @_;
+
+    # exactly like load_settings_from_yaml without the YAML part.
+
+    $SETTINGS = Hash::Merge::Simple::merge( $SETTINGS, {
+        map {
+            $_ => Dancer::Config->normalize_setting( $_, $config->{$_} )
+        } keys %$config
+    } );
+
+    return scalar keys %$config;
 }
 
 sub load_settings_from_yaml {

--- a/lib/Dancer/Cookbook.pod
+++ b/lib/Dancer/Cookbook.pod
@@ -753,7 +753,15 @@ like we do above with config->{environment}='production'. Of course, this value
 does not get written in any file; it only lives in memory and your webapp
 doesn't have access to it, but you can use it inside your script.
 
+If you need to load values from somewhere custom (maybe your configuration lives
+in an external data source like an SQL server or a ZooKeeper instance), you can
+use a variant of C<Dancer::Config::load()>:
 
+    my $custom_config_hashref = $zookeeper->get('/path/to/dancer/config');
+    Dancer::Config::load($custom_config_hashref);
+
+This form of C<load()> grabs configuration values from the YAML files as usual,
+but it also applies the values found in C<$custom_config_hashref>.
 
 =head2 Logging
 

--- a/lib/Dancer/Cookbook.pod
+++ b/lib/Dancer/Cookbook.pod
@@ -757,7 +757,7 @@ If you need to load values from somewhere custom (maybe your configuration lives
 in an external data source like an SQL server or a ZooKeeper instance), you can
 use a variant of C<Dancer::Config::load()>:
 
-    my $custom_config_hashref = $zookeeper->get('/path/to/dancer/config');
+    my $custom_config_hashref = from_json($zookeeper->get('/path/to/dancer/config'));
     Dancer::Config::load($custom_config_hashref);
 
 This form of C<load()> grabs configuration values from the YAML files as usual,

--- a/t/01_config/09_load_settings_from_hashref.t
+++ b/t/01_config/09_load_settings_from_hashref.t
@@ -1,0 +1,70 @@
+use strict;
+use warnings;
+use Test::More import => ['!pass'];
+
+plan skip_all => "YAML needed to run this tests"
+    unless Dancer::ModuleLoader->load('YAML');
+plan skip_all => "File::Temp 0.22 required"
+    unless Dancer::ModuleLoader->load( 'File::Temp', '0.22' );
+plan tests => 6;
+
+use Dancer ':syntax';
+use File::Spec;
+use lib File::Spec->catdir( 't', 'lib' );
+use TestUtils;
+
+my $dir = File::Temp::tempdir(CLEANUP => 1, TMPDIR => 1);
+set appdir => $dir;
+my $envdir = File::Spec->catdir($dir, 'environments');
+mkdir $envdir;
+
+my $conffile = Dancer::Config->conffile;
+
+# create the conffile
+my $conf = '
+port: 4500
+charset: "UTF8"
+startup_info: 0
+logger: file
+log: info
+structure:
+  key1: value1
+  key2: value2
+';
+write_file($conffile => $conf);
+
+# create the env file
+my $test_env = '
+startup_info: 1
+foo_test: 54
+';
+write_file(Dancer::Config->environment_file, $test_env);
+
+ok(Dancer::Config->load({ startup_info => 2,
+                          structure => { key1 => 'modified_value1',
+                                         key3 => 'added_value3' } }),
+   'load settings from hashref');
+
+# regular cases:
+is(setting('port'),
+   4500,
+   'settings from the config file are used');
+is(setting('foo_test'),
+   54,
+   'settings from the env file are used');
+is(setting('log'),
+   'info',
+   'settings from the env file still override the config file');
+is(setting('startup_info'),
+   2,
+   'settings from the hashref override both');
+is_deeply(setting('structure'),
+          { key1 => 'modified_value1',
+            key2 => 'value2',
+            key3 => 'added_value3' },
+          'settings from the hashref are deep-merged like the rest');
+
+Dancer::Logger::logger->{fh}->close;
+unlink Dancer::Config->environment_file;
+unlink $conffile;
+File::Temp::cleanup();

--- a/t/01_config/09_load_settings_from_hashref.t
+++ b/t/01_config/09_load_settings_from_hashref.t
@@ -6,7 +6,7 @@ plan skip_all => "YAML needed to run this tests"
     unless Dancer::ModuleLoader->load('YAML');
 plan skip_all => "File::Temp 0.22 required"
     unless Dancer::ModuleLoader->load( 'File::Temp', '0.22' );
-plan tests => 6;
+plan tests => 9;
 
 use Dancer ':syntax';
 use File::Spec;
@@ -17,6 +17,13 @@ my $dir = File::Temp::tempdir(CLEANUP => 1, TMPDIR => 1);
 set appdir => $dir;
 my $envdir = File::Spec->catdir($dir, 'environments');
 mkdir $envdir;
+
+ok(Dancer::Config->load({ different => 'config' }),
+   'load settings entirely from hashref');
+
+is(setting('different'),
+   'config',
+   'settings from hashref can be read');
 
 my $conffile = Dancer::Config->conffile;
 
@@ -55,6 +62,8 @@ is(setting('foo_test'),
 is(setting('log'),
    'info',
    'settings from the env file still override the config file');
+
+# hashref cases:
 is(setting('startup_info'),
    2,
    'settings from the hashref override both');
@@ -63,6 +72,10 @@ is_deeply(setting('structure'),
             key2 => 'value2',
             key3 => 'added_value3' },
           'settings from the hashref are deep-merged like the rest');
+
+is(setting('different'),
+   'config',
+   'settings from an old hashref are still set');
 
 Dancer::Logger::logger->{fh}->close;
 unlink Dancer::Config->environment_file;


### PR DESCRIPTION
Provide configuration explicitly.

This fixes issues where the configuration source is not a YAML file.  (It can be
used in combination with YAML files, but it is not intended to.)  E.g.:

    my $config = from_json($zookeeper->get('/dancer-apps/the-app/config'));
    Dancer::Config->load($config);

This replaces the workaround:

    my $config = from_json($zookeeper->get('/dancer-apps/the-app/config'));
    foreach my $key (keys %{$config}) {
      setting $key => $config->{$key};
    }

which does not work when some settings have hooks.  For instance, you can't put
the logger configuration in there, because you have no guarantee that the "log"
key will be read after the "log_config" key.  When the "log" key is read, the
corresponding logger class is loaded and init'd, but the logger configuration is
sometimes not available yet.

With `load($config)`, we use the normal Dancer config loading mechanisms, which
fire all config hooks *after* the config has been fully loaded.

This change is backwards-compatible and includes doc and tests. It's more intended for advanced users writing their own configuration mechanisms since the existing Dancer init stuff doesn't use it.