### PR TITLE
Check upon retrieval that the id is kosher

### DIFF
--- a/lib/Dancer/Session/YAML.pm
+++ b/lib/Dancer/Session/YAML.pm
@@ -60,6 +60,12 @@ sub reset {
 # Return the session object corresponding to the given id
 sub retrieve {
     my ($class, $id) = @_;
+
+    unless( $id =~ /^[\da-z]+$/i ) {
+        warn "session id '$id' contains illegal characters\n";
+        return;
+    }
+
     my $session_file = yaml_file($id);
 
     return unless -f $session_file;
@@ -74,7 +80,8 @@ sub retrieve {
 # instance
 
 sub yaml_file {
-    my ($id) = @_;
+    my $id = shift;
+
     return path(setting('session_dir'), "$id.yml");
 }
 


### PR DESCRIPTION
If not, warn and refuse to use it (a new id will be automatically generated)