### PR TITLE
Fix spurious test failure due to platform specific directory separators

### DIFF
--- a/t/01_config/06_stack_trace.t
+++ b/t/01_config/06_stack_trace.t
@@ -32,7 +32,7 @@ plan tests => 18;
     like $error_lines[1] 
         => qr!^\s*Dancer::Template::TemplateToolkit::render\(['"]?Dancer::Template::TemplateToolkit=HASH\(0x[0-9a-fA-F]+\)['"]?, ['"]/not/a/valid/file['"]\) called at!, 
         "test verbose croak stack trace";
-    like($error_lines[2], qr!^\s*eval \{...\} called at (?:[.]/)?t/01_config/06_stack_trace.t!, "test verbose croak stack trace");
+    like($error_lines[2], qr!^\s*eval \{...\} called at (?:[.]/)?\Q$0\E!, "test verbose croak stack trace");
 }
 
 {
@@ -58,5 +58,5 @@ plan tests => 18;
     like $error_lines[1] 
         => qr!^\s*Dancer::Template::TemplateToolkit::render\(['"]?Dancer::Template::TemplateToolkit=HASH\(0x[0-9a-fA-F]+\)['"]?, ['"]/not/a/valid/file['"]\) called at!, 
         "test verbose croak stack trace";
-    like($error_lines[2], qr!^\s*eval \{...\} called at (?:[.]/)?t/01_config/06_stack_trace.t!, "test verbose croak stack trace");
+    like($error_lines[2], qr!^\s*eval \{...\} called at (?:[.]/)?\Q$0\E!, "test verbose croak stack trace");
 }


### PR DESCRIPTION
Use `\Q$0\E` to include the name of the current test file rather than hard-coding `t/01_config/06_stack_trace.t`.

On Windows with Visual Studio built `perl`s, `nmake test` invokes the test file with `t\01_config\06_stack_trace.t` which causes the stacktrace not to match the regular expression with the hard-coded Unix style directory separators.