### PR TITLE
fixed text encoding in abstract logger

### DIFF
--- a/lib/Dancer/Logger/Abstract.pm
+++ b/lib/Dancer/Logger/Abstract.pm
@@ -62,7 +62,7 @@ sub format_message {
     my ($self, $level, $message) = @_;
     chomp $message;
 
-    if (!Encode::is_utf8($message) && setting('charset')) {
+    if (setting('charset')) {
         $message = Encode::encode(setting('charset'), $message);
     }
 


### PR DESCRIPTION
This dancer app demonstrates the bug this PR fixes:

```perl
use utf8;
use Dancer;
use Encode qw(decode_utf8 is_utf8);

set charset => 'UTF-8';
set logger  => 'console';

get '/' => sub {
    my $text = decode_utf8 '☺☺☺';
    debug "is_utf8: " . is_utf8($text);
    debug "text: $text";
    return "$text\n";
};

dance;
```

When that endpoint is requested, the console displays:


    == Entering the development dance floor ...
    [8717] debug @0.000373> [hit #1]is_utf8: 1 in foo.pl l. 10
    Wide character in print at /home/naveed/projects/Dancer/lib/Dancer/Logger/Console.pm line 10, <DATA> line 16.
    [8717] debug @0.000434> [hit #1]text: ☺☺☺ in foo.pl l. 11

Notice the `Wide character in print`. This is a critical issue when using `Dancer::Logger::Syslog` because for some reason printing a wide character to syslog results in a fatal error.

This is the offending code:


```perl
    if (!Encode::is_utf8($message) && setting('charset')) {
```
This is a bug because `is_utf8` will return true for text that is properly utf8 decoded, as my sample code demonstrates. This causes the decoded text to not get encoded before being logged.

Running the same sample code on this branch results in:

    == Entering the development dance floor ...
    [7726] debug @0.000372> [hit #1]is_utf8: 1 in foo.pl l. 10
    [7726] debug @0.000444> [hit #1]text: ☺☺☺ in foo.pl l. 11
