### PR TITLE
Fix temporary directory handling in serializer API test

### DIFF
--- a/t/14_serializer/06_api.t
+++ b/t/14_serializer/06_api.t
@@ -55,16 +55,15 @@ SKIP: {
     set serializer => 'Mutable';
     my $s = Dancer::Serializer->engine;
 
-    # Ensure the temp directory is resolved before we destroy the environment
-    # (since it needs the environment to do so, and caches after the first time)
-    File::Spec->tmpdir;
-    
+    my $tmpdir = File::Spec->tmpdir;
+
     %ENV = (
         'REQUEST_METHOD'    => 'GET',
         'HTTP_CONTENT_TYPE' => 'application/json',
         'HTTP_ACCEPT'       => 'text/xml',
         'HTTP_ACCEPT_TYPE'  => 'text/x-yaml',
         'PATH_INFO'         => '/',
+        'TMPDIR'            => $tmpdir,
     );
 
     my $req = Dancer::Request->new( env => \%ENV );
@@ -77,6 +76,7 @@ SKIP: {
     %ENV = (
         'REQUEST_METHOD' => 'PUT',
         'PATH_INFO'      => '/',
+        'TMPDIR'         => $tmpdir,
     );
     $req = Dancer::Request->new( env => \%ENV );
     Dancer::SharedData->request($req);
@@ -90,6 +90,7 @@ SKIP: {
         'PATH_INFO'      => '/',
         'HTTP_ACCEPT'    => 'text/xml',
         'CONTENT_TYPE'   => 'application/json',
+        'TMPDIR'         => $tmpdir,
     );
     $req = Dancer::Request->new( env => \%ENV );
     Dancer::SharedData->request($req);


### PR DESCRIPTION
*Even on those systems where the test seemingly succeeds, this test
file does not respect the user's configured temporary directory.*

The test file t/14_serializer/06_api.t contains a [misleading comment][3]:

>    # Ensure the temp directory is resolved before we destroy the
>    # environment (since it needs the environment to do so, and
>    # caches after the first time)
>    File::Spec->tmpdir;

which implies that the author thought the cached tmpdir value would be
preserved even when all the environment variables used by
`File::Spec->tmpdir` are purged from `%ENV`.

This assumption is incorrect.

An inspection of [File::Spec::Unix][1] shows clearly that the cached
value of `tmpdir` is invalidated in this instance. This happens on all
platforms.

On *nix systems, `File::Spec->tmpdir` falls back to using `/tmp` if it
cannot resolve a temporary directory using `$ENV{TMPDIR}`. This enables
the tests to succeed, but the tests do not used the supposedly cached
`tmpdir` from the call above. They use `/tmp`.

Looking at [File::Spec::Win32][2], we note that `tmpdir` tries to fall
back to using one of the following hardcoded locations if it cannot resolve
a temporary directory location from commonly used environment variables:
`SYS:/temp`, `C:\system\temp`, `C:/temp`, `/tmp`, and `/`.

Modern Windows systems do not contain any of these directories out of the
box. Therefore, the value cached by `File::Spec->tmpdir` is invalidated
when the relevant environment variables are removed from `%ENV`.

Consequently, it returns `/` as the temporary directory
location which, on the system I am using to test CPAN modules,  results in
the following test failure:

    Error in tempfile() using template \XXXXXXXXXX: Could not create temp file
    \IpjtLLGiT3: Permission denied at
    C:/opt/perl-5.22.0/site/lib/HTTP/Body/OctetStream.pm line 33.
    # Looks like you planned 18 tests but ran 15.
    # Looks like your test exited with 13 just after 15.
    t\14_serializer\06_api.t ............................
    Dubious, test returned 13 (wstat 3328, 0xd00)
    Failed 3/18 subtests

On other systems, the problem may be hidden by the fact that `/tmp` is there,
or maybe because there is a `C:\Temp`, or maybe because the root directory is
writable by anyone etc.

*Even on those systems where the test seemingly succeeds, this test
file does not respect the user's configured temporary directory.*

The solution is to include `TMPDIR` in the reduced `%ENV` hash. `$ENV{TMPDIR}`
is respected by `File::Spec` on all OS it supports.

 [1]: https://metacpan.org/source/SMUELLER/PathTools-3.47/lib/File/Spec/Unix.pm#L207
 [2]: https://metacpan.org/source/SMUELLER/PathTools-3.47/lib/File/Spec/Win32.pm#L70
 [3]: https://github.com/PerlDancer/Dancer/blob/devel/t/14_serializer/06_api.t#L58