### PR TITLE
Remove raw request body from RAM

### DIFF
--- a/lib/Dancer/Request.pm
+++ b/lib/Dancer/Request.pm
@@ -29,7 +29,7 @@ __PACKAGE__->attributes(
     # query
     'env',          'path',    'method',
     'content_type', 'content_length',
-    'body',         'id',
+    'id',
     'uploads',      'headers', 'path_info',
     'ajax',         'is_forward',
     @http_env_keys,
@@ -99,6 +99,18 @@ sub is_delete             { $_[0]->{method} eq 'DELETE' }
 sub is_patch              { $_[0]->{method} eq 'PATCH' }
 sub header                { $_[0]->{headers}->header($_[1]) }
 
+# We used to store the whole raw unparsed body; this was a big problem for large
+# file uploads (Issue 1129).  This convenient accessor should suit the
+# requirements of anyone who was fetching the request body, without having file
+# uploads stored in RAM.
+sub body {
+    my $http_body = shift->{_http_body} or return;
+    my $body_fh = $http_body->body or return;
+    my $raw_body = join '', $body_fh->getlines;
+    warn "request->body convenience method called, returning: [$raw_body]";
+    return $raw_body;
+}
+
 # public interface compat with CGI.pm objects
 sub request_method { method(@_) }
 sub Vars           { params(@_) }
@@ -111,7 +123,6 @@ sub init {
     $self->{path}           = undef;
     $self->{method}         = undef;
     $self->{params}         = {};
-    $self->{body}           = '';
     $self->{is_forward}     ||= 0;
     $self->{content_length} = $self->env->{CONTENT_LENGTH} || 0;
     $self->{content_type}   = $self->env->{CONTENT_TYPE} || '';
@@ -164,8 +175,12 @@ sub new_for_request {
     $req->{params}        = {%{$req->{params}}, %{$params}};
     $req->_build_params();
     $req->{_query_params} = $req->{params};
-    $req->{body}          = $body    if defined $body;
     $req->{headers}       = $headers || HTTP::Headers->new;
+
+    # We would normally have read the request into the HTTP::Body object in
+    # chunks in _read_to_end(), but here we need to do it in one hit as we were
+    # passed the body to use:
+    $req->{_http_body}->add($body);
 
     return $req;
 }
@@ -192,7 +207,6 @@ sub forward {
     $new_request->{_query_params} = $request->{_query_params};
     $new_request->{_route_params} = $request->{_route_params};
     $new_request->{_params_are_decoded} = 1;
-    $new_request->{body}    = $request->body;
     $new_request->{headers} = $request->headers;
 
     if( my $session = Dancer::Session->engine 
@@ -535,13 +549,12 @@ sub _read_to_end {
         my $body = '';
 
         while ( my $buffer = $self->_read ) {
-            $body .= $buffer;
+            $self->{_http_body}->add($buffer);
         }
 
-        $self->{_http_body}->add( $self->{body} = $body );
     }
 
-    return $self->{body};
+    return $self->{_http_body}->body;
 }
 
 sub _has_something_to_read {

--- a/lib/Dancer/Request.pm
+++ b/lib/Dancer/Request.pm
@@ -104,8 +104,8 @@ sub header                { $_[0]->{headers}->header($_[1]) }
 # requirements of anyone who was fetching the request body, without having file
 # uploads stored in RAM.
 sub body {
-    my $http_body = shift->{_http_body} or return;
-    my $body_fh = $http_body->body or return;
+    my $http_body = shift->{_http_body} or return '';
+    my $body_fh = $http_body->body or return '';
     $body_fh->seek(0, 0);
     my $raw_body = join '', $body_fh->getlines;
     return $raw_body;

--- a/lib/Dancer/Request.pm
+++ b/lib/Dancer/Request.pm
@@ -504,7 +504,7 @@ sub _parse_post_params {
     my ($self) = @_;
     return $self->{_body_params} if defined $self->{_body_params};
 
-    my $body = $self->_read_to_end();
+    $self->_read_to_end();
     $self->{_body_params} = $self->{_http_body}->param;
 }
 
@@ -554,7 +554,7 @@ sub _read_to_end {
 
     }
 
-    return $self->{_http_body}->body;
+    return $self->{_http_body};
 }
 
 sub _has_something_to_read {

--- a/lib/Dancer/Request.pm
+++ b/lib/Dancer/Request.pm
@@ -106,8 +106,8 @@ sub header                { $_[0]->{headers}->header($_[1]) }
 sub body {
     my $http_body = shift->{_http_body} or return;
     my $body_fh = $http_body->body or return;
+    $body_fh->seek(0, 0);
     my $raw_body = join '', $body_fh->getlines;
-    warn "request->body convenience method called, returning: [$raw_body]";
     return $raw_body;
 }
 

--- a/lib/Dancer/Test.pm
+++ b/lib/Dancer/Test.pm
@@ -313,7 +313,7 @@ sub dancer_response {
         elsif ( $args->{body} ) {
             $content      = $args->{body};
             $content_type = $args->{content_type}
-                || 'application/x-www-form-urlencoded';
+                || 'text/plain';
 
             # coerce hashref into an url-encoded string
             if ( ref($content) && ( ref($content) eq 'HASH' ) ) {
@@ -324,6 +324,7 @@ sub dancer_response {
                     push @tokens, "${name}=${value}";
                 }
                 $content = join( '&', @tokens );
+                $content_type = 'application/x-www-form-urlencoded';
             }
         }
         elsif ( $args->{files} ) {

--- a/t/02_request/14_uploads.t
+++ b/t/02_request/14_uploads.t
@@ -6,6 +6,7 @@ use Dancer::Request;
 use Dancer::Test;
 use Dancer::FileUtils;
 use Test::More 'import' => ['!pass'];
+use Digest::MD5;
 
 plan skip_all => "File::Temp 0.22 required"
     unless Dancer::ModuleLoader->load( 'File::Temp', '0.22' );
@@ -63,7 +64,7 @@ SHOGUN6
 $content =~ s/\r\n/\n/g;
 $content =~ s/\n/\r\n/g;
 
-plan tests => 21;
+plan tests => 22;
 
 do {
     open my $in, '<', \$content;
@@ -145,8 +146,13 @@ post(
     '/upload',
     sub {
         my $file = upload('test');
-        is $file->{filename}, $dest_file;
-        return $file->content;
+        diag "/upload handler dealing with file uploaded as named param"
+            . " test with filename " . $file->{filename};
+        is $file->{filename}, $dest_file, "Uploaded file with right filename";
+
+        # Return the filename and MD5 hash of the content so we can
+        # double-check we got what we expected:
+        return join ":", 'test', Digest::MD5::md5_hex($file->content);
     }
 );
 
@@ -155,10 +161,10 @@ post(
     sub {
         my $content;
         my $uploads = request->uploads;
-        foreach my $u (keys %$uploads){
-            $content .= $uploads->{$u}->content;
-        }
-        return $content;
+        return join ";",
+            map {
+                join ":", $_, Digest::MD5::md5_hex($uploads->{$_}->content)
+            } sort keys %$uploads;
     }
 );
 
@@ -170,7 +176,9 @@ close $fh;
 my $resp =
   dancer_response( 'POST', '/upload',
     { files => [ { name => 'test', filename => $dest_file } ] } );
-is $resp->content, $content;
+is $resp->content,
+    'test:acbd18db4cc2f85cedef654fccc4a4d8',
+    "Expected response for a single file upload";    
 
 my $files;
 for (qw/a b c/){
@@ -182,5 +190,34 @@ for (qw/a b c/){
 }
 
 $resp =  dancer_response( 'POST', '/uploads', {files => $files});
-is length($resp->content), 3;
-like $resp->content, qr/a/;
+is $resp->content, 
+    join(';',"a:0cc175b9c0f1b6a831c399e269772661",
+    "b:92eb5ffee6ae2fec3ad71c777531578f",
+    "c:4a8a08f09d37b73795649038408b5f33"),
+    "Expected response for multi uploads";
+
+
+
+## test #23
+# create a file, 256MB of zeros
+$dest_file = File::Spec->catfile($dest_dir, "zeros");
+system("dd if=/dev/zero of=$dest_file count=500000 bs=1024");
+my $digest = Digest::MD5->new;
+open(my $zerosfh, "<", $dest_file)
+    or die "Failed to open $dest_file - $!";
+my $digest = Digest::MD5->new;
+$digest->addfile($zerosfh);
+my $expect_md5 = $digest->hexdigest;
+undef $digest;
+close $zerosfh;
+
+my $bigf_resp =
+  dancer_response( 'POST', '/upload',
+    { files => [ { name => 'test', filename => $dest_file } ] } );
+is(
+    $bigf_resp->content, 
+    "test:$expect_md5",
+    "Large file uploaded OK"
+);
+
+

--- a/t/02_request/14_uploads.t
+++ b/t/02_request/14_uploads.t
@@ -201,8 +201,7 @@ is $resp->content,
 ## test #23
 # create a file, 256MB of zeros
 $dest_file = File::Spec->catfile($dest_dir, "zeros");
-system("dd if=/dev/zero of=$dest_file count=500000 bs=1024");
-my $digest = Digest::MD5->new;
+system("dd if=/dev/zero of=$dest_file count=250000 bs=1024");
 open(my $zerosfh, "<", $dest_file)
     or die "Failed to open $dest_file - $!";
 my $digest = Digest::MD5->new;

--- a/t/23_dancer_tests/01_basic.t
+++ b/t/23_dancer_tests/01_basic.t
@@ -1,4 +1,4 @@
-use Test::More import => ['!pass'], tests => 20;
+use Test::More import => ['!pass'], tests => 21;
 
 use strict;
 use warnings;
@@ -37,8 +37,11 @@ response_headers_include [GET => '/with_headers'], [ 'X-Foo-Dancer' => '42' ];
 my $resp = dancer_response(@$req);
 is $resp->{status}, 200, "response status from dancer_response looks good";
 
+
+response_content_is [POST => '/jsondata', { body => 42 }], 42,
+    "a POST request with a body looks good";
 response_content_is [PUT => '/jsondata', { body => 42 }], 42,
-    "a request with a body looks good";
+    "a PUT request with a body looks good";
 
 response_content_is [POST => '/name', { params => {name => 'Bob'} }],
     "Your name: Bob", "a request with params looks good";

--- a/t/lib/TestApp.pm
+++ b/t/lib/TestApp.pm
@@ -59,7 +59,7 @@ get '/read_session' => sub {
     "name='$name'"
 };
 
-put '/jsondata' => sub {
+any['put','post'] => '/jsondata' => sub {
     request->body;
 };
 


### PR DESCRIPTION
This is for Issue #1129 - where large file uploads easily cause the Dancer process to exhaust available memory.

Currently, we keep a copy of the entire raw HTTP request in the `Dancer::Request` object.

This PR changes that, replacing that attribute with a convenient accessor which reads the request body content from the temp file that `HTTP::Body` will have set up for us, so that code that expects to be able to fetch the request body with `request->body` can still do so, so there should be no backwards-incompatible breakage (in theory!).

As per the results in #1129, this drastically reduces memory usage while handling large file uploads - for instance, the RSS (memory used) after handling a file upload for latest CPAN version: 2,260,084 kilobytes, with this PR: 510,056 kilobytes.

I still need to decide whether to keep the large file uploading test added here, and if so, whether it should be an author-testing only one due to the need to generate a large file and reliance on dd, or whether it can go away now that the work is done, but raised a PR already for discussion.