### PR TITLE
Bind to localhost during testing

### DIFF
--- a/t/00_base/12_utf8_charset.t
+++ b/t/00_base/12_utf8_charset.t
@@ -38,6 +38,7 @@ Test::TCP::test_tcp(
         use t::lib::TestAppUnicode;
 
         set( charset      => 'utf8',
+             host         => '127.0.0.1',
              port         => $port,
              show_errors  => 1,
              startup_info => 0,

--- a/t/02_request/07_raw_data.t
+++ b/t/02_request/07_raw_data.t
@@ -37,6 +37,7 @@ Test::TCP::test_tcp(
 
         set( environment  => 'production',
              port         => $port,
+             server       => '127.0.0.1',
              startup_info => 0);
         Dancer->dance();
     },

--- a/t/02_request/10_mixed_params.t
+++ b/t/02_request/10_mixed_params.t
@@ -53,6 +53,7 @@ Test::TCP::test_tcp(
 
         set ( environment  => 'production',
               port         => $port,
+              server       => '127.0.0.1',
               startup_info => 0);
         Dancer->dance();
     },

--- a/t/02_request/13_ajax.t
+++ b/t/02_request/13_ajax.t
@@ -30,6 +30,7 @@ Test::TCP::test_tcp(
         my $port = shift;
         use Dancer;
         set (port         => $port,
+             server       => '127.0.0.1',
              startup_info => 0);
 
         get '/req' => sub {

--- a/t/02_request/15_headers.t
+++ b/t/02_request/15_headers.t
@@ -38,6 +38,7 @@ Test::TCP::test_tcp(
 
         set( apphandler   => $handler,
              port         => $port,
+             server       => '127.0.0.1',
              show_errors  => 1,
              startup_info => 0 );
 

--- a/t/03_route_handler/21_ajax.t
+++ b/t/03_route_handler/21_ajax.t
@@ -68,7 +68,7 @@ Test::TCP::test_tcp(
         use Dancer;
         use Dancer::Plugin::Ajax;
 
-        set startup_info => 0, port => $port, layout => 'wibble';
+        set startup_info => 0, port => $port, server => '127.0.0.1', layout => 'wibble';
 
         ajax '/req' => sub {
             return 1;

--- a/t/03_route_handler/33_vars.t
+++ b/t/03_route_handler/33_vars.t
@@ -32,7 +32,7 @@ Test::TCP::test_tcp(
         # vars should be reset before the handler is called
         var foo => 42;
 
-        set startup_info => 0, port => $port;
+        set startup_info => 0, port => $port, server => '127.0.0.1';
 
         get "/getvarfoo" => sub {
             return ++vars->{foo};

--- a/t/03_route_handler/34_forward_body_post.t
+++ b/t/03_route_handler/34_forward_body_post.t
@@ -42,7 +42,7 @@ Test::TCP::test_tcp(
 
       post '/foz' => sub { forward '/baz';  };
       post '/baz' => sub { join(":",params('body')) };
-      set startup_info => 0, port => $port, show_errors  => 1;
+      set startup_info => 0, port => $port, server => '127.0.0.1', show_errors  => 1;
       Dancer->dance();
   },
                    );

--- a/t/04_static_file/001_base.t
+++ b/t/04_static_file/001_base.t
@@ -62,7 +62,7 @@ Test::TCP::test_tcp(
         setting apphandler => 'PSGI';
         Dancer::Config->load;
         my $app = Dancer::Handler->psgi_app;
-        Plack::Loader->auto( port => $port )->run($app);
+        Plack::Loader->auto( port => $port, host => '127.0.0.1' )->run($app);
         Dancer->dance();
     }
 );
@@ -83,7 +83,7 @@ Test::TCP::test_tcp(
         setting apphandler => 'PSGI';
         Dancer::Config->load;
         my $app = Dancer::Handler->psgi_app;
-        Plack::Loader->auto( port => $port )->run($app);
+        Plack::Loader->auto( port => $port, host => '127.0.0.1' )->run($app);
         Dancer->dance();
     }
 );

--- a/t/07_apphandlers/03_psgi_app.t
+++ b/t/07_apphandlers/03_psgi_app.t
@@ -44,6 +44,6 @@ Test::TCP::test_tcp(
         set apphandler  => 'PSGI', environment => 'production';
         Dancer::Config->load;
 
-        Plack::Loader->auto(port => $port)->run($app);
+        Plack::Loader->auto(port => $port, server => '127.0.0.1')->run($app);
     },
 );

--- a/t/07_apphandlers/04_standalone_app.t
+++ b/t/07_apphandlers/04_standalone_app.t
@@ -46,6 +46,7 @@ Test::TCP::test_tcp(
         use TestApp;
         Dancer::Config->load;
         set( port         => $port,
+             server       => '127.0.0.1',
              startup_info => 0 );
         Dancer->dance();
     },

--- a/t/07_apphandlers/05_middlewares.t
+++ b/t/07_apphandlers/05_middlewares.t
@@ -42,10 +42,11 @@ foreach my $c (@$confs) {
             set( environment       => 'production',
                  apphandler        => 'PSGI',
                  port              => $port,
+                 server            => '127.0.0.1',
                  startup_info      => 0,
                  plack_middlewares => $c->[0] );
             my $app = Dancer::Handler->get_handler()->dance;
-            Plack::Loader->auto( port => $port )->run($app);
+            Plack::Loader->auto( port => $port, server => '127.0.0.1' )->run($app);
         },
     );
 

--- a/t/07_apphandlers/07_middleware_map.t
+++ b/t/07_apphandlers/07_middleware_map.t
@@ -52,10 +52,11 @@ Test::TCP::test_tcp(
         set( environment           => 'production',
              apphandler            => 'PSGI',
              port                  => $port,
+             server                => '127.0.0.1',
              startup_info          => 0,
              plack_middlewares_map => $confs );
 
         my $app = Dancer::Handler->get_handler()->dance;
-        Plack::Loader->auto( port => $port )->run($app);
+        Plack::Loader->auto( port => $port, server => '127.0.0.1' )->run($app);
     },
 );

--- a/t/08_session/03_http_requests.t
+++ b/t/08_session/03_http_requests.t
@@ -73,7 +73,8 @@ Test::TCP::test_tcp(
         set( show_errors  => 1,
              startup_info => 0,
              environment  => 'production',
-             port         => $port );
+             port         => $port,
+             server       => '127.0.0.1' );
         Dancer->dance();
     },
 );

--- a/t/08_session/07_session_expires.t
+++ b/t/08_session/07_session_expires.t
@@ -64,6 +64,7 @@ for my $session_expires (keys %tests) {
                  session_expires => $session_expires,
                  environment     => 'production',
                  port            => $port,
+                 server          => '127.0.0.1',
                  startup_info    => 0 );
             Dancer->dance();
         },

--- a/t/08_session/13_session_httponly.t
+++ b/t/08_session/13_session_httponly.t
@@ -57,6 +57,7 @@ for my $setting ("default", "on", "off") {
         }
         set( environment          => 'production',
              port                 => $port,
+             server               => '127.0.0.1',
              startup_info         => 0 );
         Dancer->dance();
         },

--- a/t/09_cookies/03_persistence.t
+++ b/t/09_cookies/03_persistence.t
@@ -52,7 +52,8 @@ Test::TCP::test_tcp(
 
         set( startup_info => 0,
              environment  => 'production',
-             port         => $port );
+             port         => $port,
+             server       => '127.0.0.1' );
         Dancer->dance();
     },
 );

--- a/t/12_response/04_charset_server.t
+++ b/t/12_response/04_charset_server.t
@@ -50,6 +50,7 @@ Test::TCP::test_tcp(
         set( charset      => 'utf-8',
              environment  => 'production',
              port         => $port,
+             server       => '127.0.0.1',
              startup_info => 0 );
         Dancer->dance();
     },
@@ -81,6 +82,7 @@ Test::TCP::test_tcp(
             # no charset
             environment  => 'production',
             port         => $port,
+            server       => '127.0.0.1',
             startup_info => 0,
         );
         Dancer->dance;
@@ -114,6 +116,7 @@ SKIP: {
                 # no charset
                 environment  => 'production',
                 port         => $port,
+                server       => '127.0.0.1',
                 startup_info => 0,
                 serializer   => 'JSON',
             );

--- a/t/12_response/08_drop_content.t
+++ b/t/12_response/08_drop_content.t
@@ -33,7 +33,7 @@ sub test {
         },
         server => sub {
             my $port = shift;
-            set port => $port, startup_info => 0;
+            set port => $port, server => '127.0.0.1', startup_info => 0;
 
             get '/204' => sub {
                 status 204;

--- a/t/14_serializer/17_clear_serializer.t
+++ b/t/14_serializer/17_clear_serializer.t
@@ -45,6 +45,7 @@ Test::TCP::test_tcp(
 
         set( apphandler   => 'Standalone',
              port         => $port,
+             server       => '127.0.0.1',
              show_errors  => 1,
              startup_info => 0 );
 

--- a/t/15_plugins/07_ajax_plack_builder.t
+++ b/t/15_plugins/07_ajax_plack_builder.t
@@ -53,7 +53,7 @@ Test::TCP::test_tcp(
         my $handler = sub {
             use Dancer;
 
-            set port => $port, apphandler => 'PSGI', startup_info => 0;
+            set port => $port, server => '127.0.0.1', apphandler => 'PSGI', startup_info => 0;
 
             get  '/'    => sub {$js_content};
             ajax '/foo' => sub {'bar'};

--- a/t/21_dependents/Dancer-Session-Cookie.t
+++ b/t/21_dependents/Dancer-Session-Cookie.t
@@ -54,6 +54,7 @@ test_tcp(
         use Dancer ':tests';
 
         set( port                => $port,
+             server              => '127.0.0.1',
              appdir              => '',          # quiet warnings not having an appdir
              startup_info        => 0,           # quiet startup banner
              session_cookie_key  => "John has a long mustache",


### PR DESCRIPTION
This makes tests using Test::TCP more stable as it
uses '127.0.0.1' to find available port and when
Dancer binds to '0.0.0.0' it intermittently fails on
a busy enough build server.