### PR TITLE
More solid route cache max size testing

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,6 +8,8 @@ Revision history for Dancer
  [DOCUMENTATION]
 
  [ENHANCEMENTS]
+ - Bind to 127.0.0.1 in tests to avoid occasional spurious failures on busy
+   build hosts (PR 1136, thanks to @redbaron)
 
  [NEW FEATURES]
 


### PR DESCRIPTION
I'm hoping this will be a more solid way to test that the route cache size doesn't grow larger than the limit set, and should help stop some unpredictable intermittent CPAN Testers failures like http://www.cpantesters.org/cpan/report/01b05300-726a-11e5-9ad7-6c22b4e1cf47 

See also PR 1130, which I'd thought could have been the reason for the failures I saw for the latest dev release - until I found identical failures pre-dating that PR being merged :)