### PR TITLE
replace LWP usage with HTTP::Tiny and HTTP::CookieJar (for tests)

### DIFF
--- a/bin/dancer
+++ b/bin/dancer
@@ -12,7 +12,7 @@ use File::Spec::Functions;
 use Getopt::Long;
 use Pod::Usage;
 use Dancer::Renderer;
-use LWP::UserAgent;
+use HTTP::Tiny;
 use constant FILE => 1;
 
 # options
@@ -269,14 +269,13 @@ sub write_data_to_file {
 
 sub send_http_request {
     my $url = shift;
-    my $ua = LWP::UserAgent->new;
+    my $ua = HTTP::Tiny->new;
     $ua->timeout(5);
-    $ua->env_proxy();
 
     my $response = $ua->get($url);
 
-    if ($response->is_success) {
-        return $response->content;
+    if ($response->{success}) {
+        return $response->{content};
     }
     else {
         return;

--- a/dist.ini
+++ b/dist.ini
@@ -19,6 +19,8 @@ upstream=origin
 
 authority=cpan:SUKRIA
 
+[Prereqs / RuntimeRequires]
+HTTP::Tiny = 0.014 ; for get/post/post_form
 
 [Prereqs / RuntimeRecommends ]
 YAML = 0

--- a/lib/Dancer.pm
+++ b/lib/Dancer.pm
@@ -1962,7 +1962,7 @@ The following modules are mandatory (Dancer cannot run without them):
 
 =item L<HTTP::Body>
 
-=item L<LWP>
+=item L<HTTP::Tiny>
 
 =item L<MIME::Types>
 

--- a/t/02_request/07_raw_data.t
+++ b/t/02_request/07_raw_data.t
@@ -10,7 +10,7 @@ plan skip_all => "skip test with Test::TCP in win32/cygwin" if ($^O eq 'MSWin32'
 plan skip_all => "Test::TCP is needed for this test"
     unless Dancer::ModuleLoader->load("Test::TCP" => "1.30");
 
-use LWP::UserAgent;
+use HTTP::Tiny;
 
 use constant RAW_DATA => "var: 2; foo: 42; bar: 57\nHey I'm here.\r\n\r\n";
 
@@ -19,15 +19,12 @@ Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
         my $rawdata = RAW_DATA;
-        my $ua = LWP::UserAgent->new;
-        my $req = HTTP::Request->new(PUT => "http://127.0.0.1:$port/jsondata");
+        my $ua = HTTP::Tiny->new;
         my $headers = { 'Content-Length' => length($rawdata) };
-        $req->push_header($_, $headers->{$_}) foreach keys %$headers;
-        $req->content($rawdata);
-        my $res = $ua->request($req);
+        my $res = $ua->put("http://127.0.0.1:$port/jsondata", { headers => $headers, content => $rawdata });
 
-        ok $res->is_success, 'req is success';
-        is $res->content, $rawdata, "raw_data is OK";
+        ok $res->{success}, 'req is success';
+        is $res->{content}, $rawdata, "raw_data is OK";
     },
     server => sub {
         my $port = shift;

--- a/t/02_request/10_mixed_params.t
+++ b/t/02_request/10_mixed_params.t
@@ -11,18 +11,18 @@ plan skip_all => "skip test with Test::TCP in win32" if ($^O eq 'MSWin32' or $^O
 plan skip_all => "Test::TCP is needed for this test"
     unless Dancer::ModuleLoader->load("Test::TCP" => "1.30");
 
-use LWP::UserAgent;
+use HTTP::Tiny;
 
 plan tests => 2;
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
-        my $ua = LWP::UserAgent->new;
-        my $res = $ua->post("http://127.0.0.1:$port/params/route?a=1&var=query",
+        my $ua = HTTP::Tiny->new;
+        my $res = $ua->post_form("http://127.0.0.1:$port/params/route?a=1&var=query",
                             {var => 'post', b => 2});
 
-        ok $res->is_success, 'req is success';
-        my $content = $res->content;
+        ok $res->{success}, 'req is success';
+        my $content = $res->{content};
         my $VAR1;
         eval ("$content");
 

--- a/t/02_request/13_ajax.t
+++ b/t/02_request/13_ajax.t
@@ -7,24 +7,22 @@ plan skip_all => 'Test::TCP is needed to run this test'
     unless Dancer::ModuleLoader->load('Test::TCP' => "1.30");
 plan tests => 8;
 
-use LWP::UserAgent;
+use HTTP::Tiny;
 use HTTP::Headers;
 
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
-        my $ua = LWP::UserAgent->new;
+        my $ua = HTTP::Tiny->new;
 
-        my $request = HTTP::Request->new(GET => "http://127.0.0.1:$port/req");
-        $request->header('X-Requested-With' => 'XMLHttpRequest');
-        my $res = $ua->request($request);
-        ok($res->is_success, "server responded");
-        is($res->content, 1, "content ok");
+        my $headers = { 'X-Requested-With' => 'XMLHttpRequest' };
+        my $res = $ua->get("http://127.0.0.1:$port/req", { headers => $headers });
+        ok($res->{success}, "server responded");
+        is($res->{content}, 1, "content ok");
 
-        $request = HTTP::Request->new(GET => "http://127.0.0.1:$port/req");
-        $res = $ua->request($request);
-        ok($res->is_success, "server responded");
-        is($res->content, 0, "content ok");
+        $res = $ua->get("http://127.0.0.1:$port/req");
+        ok($res->{success}, "server responded");
+        is($res->{content}, 0, "content ok");
     },
     server => sub {
         my $port = shift;

--- a/t/03_route_handler/28_plack_mount.t
+++ b/t/03_route_handler/28_plack_mount.t
@@ -11,8 +11,7 @@ BEGIN {
       unless Dancer::ModuleLoader->load('Plack::Builder');
 }
 
-use HTTP::Request;
-use LWP::UserAgent;
+use HTTP::Tiny;
 
 use Plack::Builder; # should be loaded in BEGIN block, but it seems that it's not the case ...
 use HTTP::Server::Simple::PSGI;
@@ -24,11 +23,10 @@ Test::TCP::test_tcp(
         my $port = shift;
         my $url = "http://127.0.0.1:$port/mount/test/foo";
 
-        my $req = HTTP::Request->new(GET => $url);
-        my $ua = LWP::UserAgent->new();
-        ok my $res = $ua->request($req);
-        ok $res->is_success;
-        is $res->content, '/foo';
+        my $ua = HTTP::Tiny->new();
+        ok my $res = $ua->get($url);
+        ok $res->{success};
+        is $res->{content}, '/foo';
     },
     server => sub {
         my $port    = shift;

--- a/t/03_route_handler/33_vars.t
+++ b/t/03_route_handler/33_vars.t
@@ -5,7 +5,7 @@ use warnings;
 
 use Test::More;
 
-use LWP::UserAgent;
+use HTTP::Tiny;
 
 plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
 plan skip_all => "Test::TCP is needed for this test"
@@ -15,13 +15,10 @@ plan tests => 10;
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
-        my $ua  = LWP::UserAgent->new;
+        my $ua  = HTTP::Tiny->new;
         for (1..10) {
-            my $req = HTTP::Request->new( 
-                GET => "http://127.0.0.1:$port/getvarfoo"
-            );
-            my $res = $ua->request($req);
-            is $res->content, 1;
+            my $res = $ua->get("http://127.0.0.1:$port/getvarfoo");
+            is $res->{content}, 1;
         }
     },
     server => sub {

--- a/t/03_route_handler/34_forward_body_post.t
+++ b/t/03_route_handler/34_forward_body_post.t
@@ -15,8 +15,7 @@ BEGIN {
 }
 
 use Dancer;
-use LWP::UserAgent;
-use HTTP::Request;
+use HTTP::Tiny;
 
 plan tests => 2;
 
@@ -24,12 +23,12 @@ Test::TCP::test_tcp(
   client => sub {
       my $port = shift;
       my $url_base  = "http://127.0.0.1:$port";
-      my $ua  = LWP::UserAgent->new;
-      my $res = $ua->post($url_base . "/foo", { data => 'foo'});
-      is($res->decoded_content, "data:foo");
+      my $ua  = HTTP::Tiny->new;
+      my $res = $ua->post_form($url_base . "/foo", { data => 'foo'});
+      is($res->{content}, "data:foo");
 
-      $res = $ua->post($url_base . "/foz", { data => 'foo'});
-      is($res->decoded_content, "data:foo");
+      $res = $ua->post_form($url_base . "/foz", { data => 'foo'});
+      is($res->{content}, "data:foo");
   },
   server => sub {
       my $port = shift;

--- a/t/07_apphandlers/03_psgi_app.t
+++ b/t/07_apphandlers/03_psgi_app.t
@@ -9,7 +9,7 @@ plan skip_all => "Test::TCP is needed to run this test"
 plan skip_all => "Plack is needed to run this test"
     unless Dancer::ModuleLoader->load('Plack::Request');
 
-use LWP::UserAgent;
+use HTTP::Tiny;
 
 Dancer::ModuleLoader->load('Plack::Loader');
 
@@ -20,18 +20,18 @@ plan tests => 3;
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
-        my $ua = LWP::UserAgent->new;
+        my $ua = HTTP::Tiny->new;
 
         my $res = $ua->get("http://127.0.0.1:$port/env");
-        like $res->content, qr/psgi\.version/,
+        like $res->{content}, qr/psgi\.version/,
             'content looks good for /env';
 
         $res = $ua->get("http://127.0.0.1:$port/name/bar");
-        like $res->content, qr/Your name: bar/,
+        like $res->{content}, qr/Your name: bar/,
             'content looks good for /name/bar';
 
         $res = $ua->get("http://127.0.0.1:$port/name/baz");
-        like $res->content, qr/Your name: baz/,
+        like $res->{content}, qr/Your name: baz/,
             'content looks good for /name/baz';
     },
     server => sub {

--- a/t/07_apphandlers/04_standalone_app.t
+++ b/t/07_apphandlers/04_standalone_app.t
@@ -9,33 +9,33 @@ plan skip_all => "Test::TCP is needed for this test"
 plan skip_all => "Test::TCP is needed for this test"
     unless Dancer::ModuleLoader->load("Plack::Loader");
 
-use LWP::UserAgent;
+use HTTP::Tiny;
 
 plan tests => 6;
 
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
-        my $ua = LWP::UserAgent->new;
+        my $ua = HTTP::Tiny->new;
 
         my $res = $ua->get("http://127.0.0.1:$port/env");
-        like $res->content, qr/PATH_INFO/, 'path info is found in response';
+        like $res->{content}, qr/PATH_INFO/, 'path info is found in response';
 
         $res = $ua->get("http://127.0.0.1:$port/name/bar");
-        like $res->content, qr/Your name: bar/, 'name is found on a GET';
+        like $res->{content}, qr/Your name: bar/, 'name is found on a GET';
 
         $res = $ua->get("http://127.0.0.1:$port/name/baz");
-        like $res->content, qr/Your name: baz/, 'name is found on a GET';
+        like $res->{content}, qr/Your name: baz/, 'name is found on a GET';
 
-        $res = $ua->post("http://127.0.0.1:$port/name", { name => "xxx" });
-        like $res->content, qr/Your name: xxx/, 'name is found on a POST';
+        $res = $ua->post_form("http://127.0.0.1:$port/name", { name => "xxx" });
+        like $res->{content}, qr/Your name: xxx/, 'name is found on a POST';
 
         # we are already skipping under MSWin32 (check plan above)
         $res = $ua->get("http://127.0.0.1:$port/issues/499/true");
-        is $res->content, "OK";
+        is $res->{content}, "OK";
 
         $res = $ua->get("http://127.0.0.1:$port/issues/499/false");
-        is $res->content, "OK";
+        is $res->{content}, "OK";
     },
     server => sub {
         my $port = shift;

--- a/t/07_apphandlers/05_middlewares.t
+++ b/t/07_apphandlers/05_middlewares.t
@@ -4,7 +4,7 @@ use warnings;
 
 use Dancer ':syntax';
 use Dancer::ModuleLoader;
-use LWP::UserAgent;
+use HTTP::Tiny;
 
 use File::Spec;
 use lib File::Spec->catdir( 't', 'lib' );
@@ -26,12 +26,11 @@ foreach my $c (@$confs) {
     Test::TCP::test_tcp(
         client => sub {
             my $port = shift;
-            my $ua   = LWP::UserAgent->new;
+            my $ua   = HTTP::Tiny->new;
 
-            my $req = HTTP::Request->new( GET => "http://localhost:$port/" );
-            my $res = $ua->request($req);
+            my $res = $ua->get("http://localhost:$port/");
             ok $res;
-            ok $res->header('X-Runtime');
+            ok $res->{headers}{'x-runtime'};
         },
         server => sub {
             my $port = shift;

--- a/t/07_apphandlers/07_middleware_map.t
+++ b/t/07_apphandlers/07_middleware_map.t
@@ -4,7 +4,7 @@ use warnings;
 
 use Dancer ':syntax';
 use Dancer::ModuleLoader;
-use LWP::UserAgent;
+use HTTP::Tiny;
 
 use File::Spec;
 use lib File::Spec->catdir('t','lib');
@@ -27,19 +27,16 @@ plan tests => (2 * scalar @tests);
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
-        my $ua   = LWP::UserAgent->new;
+        my $ua   = HTTP::Tiny->new;
 
         foreach my $test (@tests) {
-            my $req =
-              HTTP::Request->new(
-                GET => "http://localhost:$port" . $test->{path} );
-            my $res = $ua->request($req);
+            my $res = $ua->get("http://localhost:$port" . $test->{path});
             ok $res;
             if ( $test->{runtime} ) {
-                ok $res->header('X-Runtime');
+                ok $res->{headers}{'x-runtime'};
             }
             else {
-                ok !$res->header('X-Runtime');
+                ok !$res->{headers}{'x-runtime'};
             }
         }
     },

--- a/t/08_session/07_session_expires.t
+++ b/t/08_session/07_session_expires.t
@@ -21,7 +21,7 @@ plan skip_all => "YAML is needed for this test"
 
 plan tests => 8;
 
-use LWP::UserAgent;
+use HTTP::Tiny;
 use File::Path 'rmtree';
 use Dancer::Config;
 
@@ -40,12 +40,10 @@ for my $session_expires (keys %tests) {
     Test::TCP::test_tcp(
         client => sub {
             my $port = shift;
-            my $ua   = LWP::UserAgent->new;
-            my $req =
-              HTTP::Request->new(GET => "http://127.0.0.1:$port/set_session/test");
-            my $res = $ua->request($req);
-            ok $res->is_success, 'req is success';
-            my $cookie = $res->header('Set-Cookie');
+            my $ua   = HTTP::Tiny->new;
+            my $res = $ua->get("http://127.0.0.1:$port/set_session/test");
+            ok $res->{success}, 'req is success';
+            my $cookie = $res->{headers}{'set-cookie'};
             ok $cookie, 'cookie is set';
             my ($expires) = ($cookie =~ /expires=(.*?);/);
             ok $expires, 'expires is present in cookie';

--- a/t/08_session/13_session_httponly.t
+++ b/t/08_session/13_session_httponly.t
@@ -14,7 +14,7 @@ plan skip_all => "YAML is needed for this test"
 
 plan tests => 3 * 3;
 
-use LWP::UserAgent;
+use HTTP::Tiny;
 use File::Path 'rmtree';
 use Dancer::Config;
 
@@ -25,12 +25,10 @@ for my $setting ("default", "on", "off") {
     Test::TCP::test_tcp(
         client => sub {
             my $port = shift;
-            my $ua   = LWP::UserAgent->new;
-            my $req =
-              HTTP::Request->new(GET => "http://127.0.0.1:$port/set_session/test_13");
-            my $res = $ua->request($req);
-            ok $res->is_success, 'req is success';
-            my $cookie = $res->header('Set-Cookie');
+            my $ua   = HTTP::Tiny->new;
+            my $res = $ua->get("http://127.0.0.1:$port/set_session/test_13");
+            ok $res->{success}, 'req is success';
+            my $cookie = $res->{headers}{'set-cookie'};
             ok $cookie, 'cookie is set';
             if ($setting eq "on" || $setting eq "default") {
                 my ($httponly) = ($cookie =~ /HttpOnly/);

--- a/t/09_cookies/03_persistence.t
+++ b/t/09_cookies/03_persistence.t
@@ -8,15 +8,13 @@ BEGIN {
     plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
     plan skip_all => 'Test::TCP is needed to run this test'
         unless Dancer::ModuleLoader->load('Test::TCP' => "1.30");
-    plan skip_all => "File::Temp 0.22 required"
-        unless Dancer::ModuleLoader->load( 'File::Temp', '0.22' );
 };
 
-use LWP::UserAgent;
+use HTTP::Tiny;
+use HTTP::CookieJar;
 use Dancer;
 
 use File::Spec;
-my $tempdir = File::Temp::tempdir(CLEANUP => 1, TMPDIR => 1);
 
 plan tests => 9;
 Test::TCP::test_tcp(
@@ -24,23 +22,20 @@ Test::TCP::test_tcp(
         my $port = shift;
 
         foreach my $client (qw(one two three)) {
-            my $ua = LWP::UserAgent->new;
-            $ua->cookie_jar({ file => "$tempdir/.cookies.txt" });
+            my $ua = HTTP::Tiny->new(cookie_jar => HTTP::CookieJar->new);
 
             my $res = $ua->get("http://127.0.0.1:$port/cookies");
-            like $res->content, qr/\$VAR1 = \{\}/,
+            like $res->{content}, qr/\$VAR1 = \{\}/,
             "no cookies found for the client $client";
 
             $res = $ua->get("http://127.0.0.1:$port/set_cookie/$client/42");
             # use YAML::Syck; warn Dump $res;
-            ok($res->is_success, "set_cookie for client $client");
+            ok($res->{success}, "set_cookie for client $client");
 
             $res = $ua->get("http://127.0.0.1:$port/cookies");
-            like $res->content, qr/'name' => '$client'/,
+            like $res->{content}, qr/'name' => '$client'/,
             "cookie looks good for client $client";
         }
-
-        File::Temp::cleanup();
     },
     server => sub {
         my $port = shift;

--- a/t/12_response/08_drop_content.t
+++ b/t/12_response/08_drop_content.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use Test::More import => ['!pass'];
-use LWP::UserAgent;
+use HTTP::Tiny;
 
 BEGIN {
     use Dancer::ModuleLoader;
@@ -23,12 +23,11 @@ sub test {
             my $port = shift;
             my $url  = "http://127.0.0.1:$port/";
 
-            my $ua = LWP::UserAgent->new;
+            my $ua = HTTP::Tiny->new;
             for (qw/204 304/) {
-                my $req = HTTP::Request->new( GET => $url . $_ );
-                my $res = $ua->request($req);
-                ok !$res->content, 'no content for '.$_;
-                ok !$res->header('Content-Length'), 'no content-length for '.$_;
+                my $res = $ua->get($url . $_);
+                ok !$res->{content}, 'no content for '.$_;
+                ok !$res->{headers}{'content-length'}, 'no content-length for '.$_;
             }
         },
         server => sub {

--- a/t/14_serializer/17_clear_serializer.t
+++ b/t/14_serializer/17_clear_serializer.t
@@ -2,7 +2,7 @@ use Dancer ':tests';
 use Dancer::Test;
 use Test::More;
 use Dancer::ModuleLoader;
-use LWP::UserAgent;
+use HTTP::Tiny;
 
 plan skip_all => "skip test with Test::TCP in win32" if  $^O eq 'MSWin32';
 plan skip_all => 'Test::TCP is needed to run this test'
@@ -20,22 +20,21 @@ my $data = { foo => 'bar' };
 Test::TCP::test_tcp(
     client => sub {
         my $port    = shift;
-        my $ua      = LWP::UserAgent->new;
-        my $request = HTTP::Request->new( GET => "http://127.0.0.1:$port/" );
+        my $ua      = HTTP::Tiny->new;
         my $res;
 
-        $res = $ua->request($request);
-        ok( $res->is_success, 'Successful response from server' );
+        $res = $ua->get("http://127.0.0.1:$port/");
+        ok( $res->{success}, 'Successful response from server' );
         like(
-            $res->content,
+            $res->{content},
             qr/"foo" \s \: \s "bar"/x,
             'Correct content',
         );
 
         # new request, no serializer
-        $res = $ua->request($request);
-        ok( $res->is_success, 'Successful response from server' );
-        like($res->content, qr/HASH\(0x.+\)/,
+        $res = $ua->get("http://127.0.0.1:$port/");
+        ok( $res->{success}, 'Successful response from server' );
+        like($res->{content}, qr/HASH\(0x.+\)/,
             'Serializer undef, response not serialised');
     },
 

--- a/t/15_plugins/07_ajax_plack_builder.t
+++ b/t/15_plugins/07_ajax_plack_builder.t
@@ -13,8 +13,7 @@ BEGIN {
       unless Dancer::ModuleLoader->load('Plack::Builder');
 }
 
-use HTTP::Request;
-use LWP::UserAgent;
+use HTTP::Tiny;
 use Plack::Builder;
 use HTTP::Server::Simple::PSGI;
 
@@ -33,19 +32,17 @@ Test::TCP::test_tcp(
         my $port = shift;
         my $url  = "http://127.0.0.1:$port/";
 
-        my $req = HTTP::Request->new(GET => $url);
-        my $ua  = LWP::UserAgent->new();
+        my $ua  = HTTP::Tiny->new();
 
-        ok my $res = $ua->request($req), 'Got GET result';
-        ok $res->is_success, 'Successful';
-        is $res->content, $js_content, 'Correct JS content';
+        ok my $res = $ua->get($url), 'Got GET result';
+        ok $res->{success}, 'Successful';
+        is $res->{content}, $js_content, 'Correct JS content';
 
-        $req = HTTP::Request->new( POST => "${url}foo" );
-        $req->header( 'X-Requested-With' => 'XMLHttpRequest' );
+        my %headers = ( 'X-Requested-With' => 'XMLHttpRequest' );
 
-        ok( $res = $ua->request($req), 'Got POST result' );
-        ok( $res->is_success, 'Successful' );
-        is( $res->content, 'bar', 'Correct content' );
+        ok( $res = $ua->post("${url}foo", { headers => \%headers }), 'Got POST result' );
+        ok( $res->{success}, 'Successful' );
+        is( $res->{content}, 'bar', 'Correct content' );
     },
 
     server => sub {

--- a/t/24_deployment/01_multi_webapp.t
+++ b/t/24_deployment/01_multi_webapp.t
@@ -13,7 +13,7 @@ BEGIN {
 
 use Dancer;
 use Plack::Builder;
-use LWP::UserAgent;
+use HTTP::Tiny;
 use HTTP::Server::Simple::PSGI;
 
 plan tests => 100;
@@ -23,12 +23,11 @@ Test::TCP::test_tcp(
         my $port = shift;
 
         my @apps = (qw/app1 app2/);
-        my $ua = LWP::UserAgent->new();
+        my $ua = HTTP::Tiny->new();
         for(1..100){
             my $app = $apps[int(rand(scalar @apps - 1))];
-            my $req = HTTP::Request->new(GET => "http://127.0.0.1:$port/$app");
-            my $res = $ua->request($req);
-            like $res->content, qr/Hello $app/;
+            my $res = $ua->get("http://127.0.0.1:$port/$app");
+            like $res->{content}, qr/Hello $app/;
         }
     },
     server => sub {

--- a/t/lib/TestUtils.pm
+++ b/t/lib/TestUtils.pm
@@ -5,6 +5,7 @@ use vars '@EXPORT';
 
 use File::Path qw(mkpath rmtree);
 use Dancer::Request;
+use HTTP::Tiny;
 
 @EXPORT =
   qw(http_request write_file clean_tmp_files);
@@ -12,9 +13,8 @@ use Dancer::Request;
 sub http_request {
     my ($port, $method, $path) = @_;
     my $url = "http://localhost:${port}${path}";
-    my $lwp = LWP::UserAgent->new;
-    my $req = HTTP::Request->new($method => $url);
-    return $lwp->request($req);
+    my $http = HTTP::Tiny->new;
+    return $http->request($method => $url);
 }
 
 sub write_file {


### PR DESCRIPTION
LWP is only used for very simple requests and test files (it is not brought in by any other dependencies), so I thought I'd give it a shot replacing it with HTTP::Tiny. Benefits of HTTP::Tiny are that it is more lightweight (in code and dependencies), and is core in 5.14+.

Things to watch out for when using HTTP::Tiny instead of LWP: No HTTP::Request or HTTP::Response, just hash references. No HTTP::Headers, but in simple cases the "headers" hashref from a response can be used directly to create a HTTP::Headers object. The "headers" in the response all have their names lowercased. There is also no decoded_content, but that was only used in one test file with ASCII responses.

HTTP::Tiny does support proxies but in a slightly different manner than LWP: https://metacpan.org/pod/HTTP::Tiny#PROXY-SUPPORT

For cookie persistence in 3 test files, HTTP::CookieJar is needed. This module, while very light, unfortunately has a requirement of perl 5.10, so either it could be made an optional test dependency, or I will see if that module can drop its perl requirement lower.

Some of the cookie tests were setting a tempfile in the cookie jar, but were never actually stored to or loaded from the tempfile, so I removed it.

The return value of the http_request function in t/lib/TestUtils.pm is now a HTTP::Tiny response hashref instead of a HTTP::Response, but it doesn't seem to be used by anything.

10 tests are removed in t/03_route_handler/21_ajax.t but they were just useless HTTP::Request constructor tests.

Comments and feedback welcome.