### PR TITLE
Fix tests failing on Linux when localhost is not mapped to 127.0.0.1.

### DIFF
--- a/t/07_apphandlers/05_middlewares.t
+++ b/t/07_apphandlers/05_middlewares.t
@@ -28,7 +28,7 @@ foreach my $c (@$confs) {
             my $port = shift;
             my $ua   = LWP::UserAgent->new;
 
-            my $req = HTTP::Request->new( GET => "http://localhost:$port/" );
+            my $req = HTTP::Request->new( GET => "http://127.0.0.1:$port/" );
             my $res = $ua->request($req);
             ok $res;
             ok $res->header('X-Runtime');

--- a/t/07_apphandlers/07_middleware_map.t
+++ b/t/07_apphandlers/07_middleware_map.t
@@ -32,7 +32,7 @@ Test::TCP::test_tcp(
         foreach my $test (@tests) {
             my $req =
               HTTP::Request->new(
-                GET => "http://localhost:$port" . $test->{path} );
+                GET => "http://127.0.0.1:$port" . $test->{path} );
             my $res = $ua->request($req);
             ok $res;
             if ( $test->{runtime} ) {


### PR DESCRIPTION
Hi! I was hoping this could be easily merged into devel.
These tests failed on machines where localhost is not mapped to 127.0.0.1.
This can happen on Linux when /etc/hosts does not contain a line similar to "127.0.0.1 localhost" or when localhost has been changed to another name.
