### PR TITLE
Build requests by hand properly

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -155,6 +155,7 @@ t/02_request/15_headers.t
 t/02_request/16_delete.t
 t/02_request/17_uri_base.t
 t/02_request/18_param_accessor.t
+t/02_request/19_json_body.t
 t/03_route_handler/01_http_methods.t
 t/03_route_handler/02_params.t
 t/03_route_handler/03_routes_api.t
@@ -360,4 +361,3 @@ t/lib/TestPlugin2.pm
 t/lib/TestPluginMRO.pm
 t/lib/TestUtils.pm
 t/pod.t
-xt/release/pause-permissions.t

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -28,3 +28,4 @@ TODO
 ^Dancer-.*
 dist.ini
 .mailmap
+xt/release/pause-permissions.t

--- a/lib/Dancer/Request.pm
+++ b/lib/Dancer/Request.pm
@@ -169,7 +169,7 @@ sub new_for_request {
         %{$extra_env},
         PATH_INFO      => $path,
         QUERY_STRING   => $query_string || $ENV{QUERY_STRING} || '',
-        REQUEST_METHOD => $method,
+        REQUEST_METHOD => $method
     };
     $env->{CONTENT_LENGTH} = length($body) if !exists $env->{CONTENT_LENGTH};
     my $req = $class->new(env => $env);

--- a/lib/Dancer/Request.pm
+++ b/lib/Dancer/Request.pm
@@ -170,8 +170,8 @@ sub new_for_request {
         PATH_INFO      => $path,
         QUERY_STRING   => $query_string || $ENV{QUERY_STRING} || '',
         REQUEST_METHOD => $method,
-        CONTENT_LENGTH => length($body),
     };
+    $env->{CONTENT_LENGTH} = length($body) if !exists $env->{CONTENT_LENGTH};
     my $req = $class->new(env => $env);
     $req->{params}        = {%{$req->{params}}, %{$params}};
     $req->_build_params();

--- a/lib/Dancer/Request.pm
+++ b/lib/Dancer/Request.pm
@@ -169,7 +169,8 @@ sub new_for_request {
         %{$extra_env},
         PATH_INFO      => $path,
         QUERY_STRING   => $query_string || $ENV{QUERY_STRING} || '',
-        REQUEST_METHOD => $method
+        REQUEST_METHOD => $method,
+        CONTENT_LENGTH => length($body),
     };
     my $req = $class->new(env => $env);
     $req->{params}        = {%{$req->{params}}, %{$params}};

--- a/t/02_request/19_json_body.t
+++ b/t/02_request/19_json_body.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+no warnings 'uninitialized';
+
+use Test::More qw(no_plan);
+
+use HTTP::Headers;
+
+use Dancer::Request;
+
+my $headers = HTTP::Headers->new;
+$headers->header('Content-Type' => 'application/json');
+$headers->header('Accept' => 'application/json');
+my $json_string = '{"json_thing":"whatever"}';
+my $request = Dancer::Request->new_for_request(
+    PATCH => '/some/url/or/another',
+    undef, $json_string, $headers,
+    {
+        CONTENT_TYPE => 'application/json',
+        HTTP_ACCEPT => 'application/json',
+        REQUEST_URI => '/some/url/or/another',
+    }
+);
+
+is($request->body, $json_string);
+
+done_testing;
+

--- a/t/02_request/19_json_body.t
+++ b/t/02_request/19_json_body.t
@@ -24,5 +24,3 @@ my $request = Dancer::Request->new_for_request(
 
 is($request->body, $json_string);
 
-done_testing;
-


### PR DESCRIPTION
This method is called by Dancer::Test::dancer_response and it was previously truncating the HTTP::Body object. I think this is a knock-on effect of the new code introduced for file uploads.