### PR TITLE
avoid uninitialized value in length warning on older perls

### DIFF
--- a/lib/Dancer/Request.pm
+++ b/lib/Dancer/Request.pm
@@ -171,7 +171,7 @@ sub new_for_request {
         QUERY_STRING   => $query_string || $ENV{QUERY_STRING} || '',
         REQUEST_METHOD => $method
     };
-    $env->{CONTENT_LENGTH} = length($body) if !exists $env->{CONTENT_LENGTH};
+    $env->{CONTENT_LENGTH} = defined($body) ? length($body) : 0 if !exists $env->{CONTENT_LENGTH};
     my $req = $class->new(env => $env);
     $req->{params}        = {%{$req->{params}}, %{$params}};
     $req->_build_params();


### PR DESCRIPTION
Causing test failures because of Test::NoWarnings
