### PR TITLE
Bind tests to 127.0.0.10, not 127.0.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: perl
-sudo: false
 
 perl:
     - "5.20"
@@ -9,9 +8,26 @@ perl:
     - "5.12"
     - "5.10"
 
-before_install:
-  - git config --global user.email "dancer-dev@dancer.pm"
-  - git config --global user.name "Perl Dancer dev team"
-  - cpanm --quiet --notest Dist::Zilla
-  - git clone git://github.com/travis-perl/helpers ~/travis-perl-helpers
-  - source ~/travis-perl-helpers/init --auto
+notifications:
+  irc:
+    channels:
+      - "irc.perl.org#dancer-core"
+    template:
+      - "%{branch}#%{build_number} by %{author}: %{message} (%{build_url})"
+    on_success: change
+    on_failure: always
+    use_notice: true
+
+install:
+#Safe fails to install due to failing tests since version 2.35 on perl < 5.14
+    - perl -E 'exit($] < 5.014)' || cpanm --no-skip-satisfied Safe || cpanm --no-skip-satisfied --notest Safe || { cat ~/.cpanm/build.log ; false ; }
+#Moo fails to install without Class::Method::Modifiers since 2012/10/19 
+    - cpanm --no-skip-satisfied Class::Method::Modifiers YAML::XS || { cat ~/.cpanm/build.log ; false ; }
+    - dzil authordeps --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
+    - dzil listdeps --author --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
+
+# We do not need sudo. Setting this allows travis to use (Docker) containers on EC2
+sudo: false
+
+script:
+    - dzil test --author --release

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,9 @@ notifications:
     on_success: change
     on_failure: always
     use_notice: true
-
+before_install:
+    - git config --global user.email "dancer-dev@dancer.pm"
+    - git config --global user.name "Perl Dancer dev team"
 install:
 #Safe fails to install due to failing tests since version 2.35 on perl < 5.14
     - perl -E 'exit($] < 5.014)' || cpanm --no-skip-satisfied Safe || cpanm --no-skip-satisfied --notest Safe || { cat ~/.cpanm/build.log ; false ; }

--- a/Changes
+++ b/Changes
@@ -8,6 +8,9 @@ Revision history for Dancer
  - Avoid request body truncation in hand-assembled requests in tests
    (PR 1148, skington)
  - Avoid tests failing when "localhost" doesn't resolve (PR 1142, gbarco)
+ - Avoid test failures due to race condition in selecting a port to listen on
+   by using 127.0.0.10 instead (more of a hacky workaround than a fix, but
+   should help (bigpresh)
 
  [DOCUMENTATION]
  - Better doc for forward_for_address (PR 1146, Relequestual)

--- a/dist.ini
+++ b/dist.ini
@@ -30,5 +30,6 @@ YAML = 0
 JSON = 2.90
 HTTP::Tiny = 0.014 ; for get/post/post_form
 HTTP::CookieJar = 0.008
+Test::TCP = 2.08; # version that started supporting bind host
 
 ; authordep Dist::Zilla::Plugin::Test::ReportPrereqs

--- a/dist.ini
+++ b/dist.ini
@@ -30,6 +30,6 @@ YAML = 0
 JSON = 2.90
 HTTP::Tiny = 0.014 ; for get/post/post_form
 HTTP::CookieJar = 0.008
-Test::TCP = 2.08; # version that started supporting bind host
+Test::TCP = 2.08 ; version that started supporting bind host
 
 ; authordep Dist::Zilla::Plugin::Test::ReportPrereqs

--- a/lib/Dancer/Handler/Debug.pm
+++ b/lib/Dancer/Handler/Debug.pm
@@ -15,7 +15,7 @@ sub run {
     my ($self, $req) = @_;
 
     my ($method, $path, $query, @env ) = @ARGV;
-    my $host    = "127.0.0.1";
+    my $host    = "127.0.0.10";
     my $port    = "3000";
 
     my $env = {

--- a/lib/Dancer/Request.pm
+++ b/lib/Dancer/Request.pm
@@ -171,7 +171,7 @@ sub new_for_request {
         QUERY_STRING   => $query_string || $ENV{QUERY_STRING} || '',
         REQUEST_METHOD => $method
     };
-    $env->{CONTENT_LENGTH} = length($body) if !exists $env->{CONTENT_LENGTH};
+    $env->{CONTENT_LENGTH} = defined($body) ? length($body) : 0 if !exists $env->{CONTENT_LENGTH};
     my $req = $class->new(env => $env);
     $req->{params}        = {%{$req->{params}}, %{$params}};
     $req->_build_params();

--- a/t/00_base/12_utf8_charset.t
+++ b/t/00_base/12_utf8_charset.t
@@ -38,7 +38,7 @@ Test::TCP::test_tcp(
         use t::lib::TestAppUnicode;
 
         set( charset      => 'utf8',
-             host         => '127.0.0.1',
+             host         => '127.0.0.10',
              port         => $port,
              show_errors  => 1,
              startup_info => 0,
@@ -61,6 +61,6 @@ sub _get_http_response {
     my ($method, $path, $port) = @_;
 
     my $ua = HTTP::Tiny->new;
-    return $ua->request($method => "http://127.0.0.1:$port${path}");
+    return $ua->request($method => "http://127.0.0.10:$port${path}");
 }
 

--- a/t/02_request/07_raw_data.t
+++ b/t/02_request/07_raw_data.t
@@ -14,6 +14,8 @@ use HTTP::Tiny;
 
 use constant RAW_DATA => "var: 2; foo: 42; bar: 57\nHey I'm here.\r\n\r\n";
 
+my $host = '127.0.0.10';
+
 plan tests => 2;
 Test::TCP::test_tcp(
     client => sub {
@@ -21,7 +23,7 @@ Test::TCP::test_tcp(
         my $rawdata = RAW_DATA;
         my $ua = HTTP::Tiny->new;
         my $headers = { 'Content-Length' => length($rawdata) };
-        my $res = $ua->put("http://127.0.0.10:$port/jsondata", { headers => $headers, content => $rawdata });
+        my $res = $ua->put("http://$host:$port/jsondata", { headers => $headers, content => $rawdata });
 
         ok $res->{success}, 'req is success';
         is $res->{content}, $rawdata, "raw_data is OK";
@@ -34,8 +36,9 @@ Test::TCP::test_tcp(
 
         set( environment  => 'production',
              port         => $port,
-             server       => '127.0.0.10',
+             server       => $host,
              startup_info => 0);
         Dancer->dance();
     },
+    host => $host,
 );

--- a/t/02_request/07_raw_data.t
+++ b/t/02_request/07_raw_data.t
@@ -21,7 +21,7 @@ Test::TCP::test_tcp(
         my $rawdata = RAW_DATA;
         my $ua = HTTP::Tiny->new;
         my $headers = { 'Content-Length' => length($rawdata) };
-        my $res = $ua->put("http://127.0.0.1:$port/jsondata", { headers => $headers, content => $rawdata });
+        my $res = $ua->put("http://127.0.0.10:$port/jsondata", { headers => $headers, content => $rawdata });
 
         ok $res->{success}, 'req is success';
         is $res->{content}, $rawdata, "raw_data is OK";
@@ -34,7 +34,7 @@ Test::TCP::test_tcp(
 
         set( environment  => 'production',
              port         => $port,
-             server       => '127.0.0.1',
+             server       => '127.0.0.10',
              startup_info => 0);
         Dancer->dance();
     },

--- a/t/02_request/10_mixed_params.t
+++ b/t/02_request/10_mixed_params.t
@@ -18,7 +18,7 @@ Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
         my $ua = HTTP::Tiny->new;
-        my $res = $ua->post_form("http://127.0.0.1:$port/params/route?a=1&var=query",
+        my $res = $ua->post_form("http://127.0.0.10:$port/params/route?a=1&var=query",
                             {var => 'post', b => 2});
 
         ok $res->{success}, 'req is success';
@@ -53,7 +53,7 @@ Test::TCP::test_tcp(
 
         set ( environment  => 'production',
               port         => $port,
-              server       => '127.0.0.1',
+              server       => '127.0.0.10',
               startup_info => 0);
         Dancer->dance();
     },

--- a/t/02_request/10_mixed_params.t
+++ b/t/02_request/10_mixed_params.t
@@ -14,11 +14,14 @@ plan skip_all => "Test::TCP is needed for this test"
 use HTTP::Tiny;
 
 plan tests => 2;
+
+my $host = '127.0.0.10';
+
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
         my $ua = HTTP::Tiny->new;
-        my $res = $ua->post_form("http://127.0.0.10:$port/params/route?a=1&var=query",
+        my $res = $ua->post_form("http://$host:$port/params/route?a=1&var=query",
                             {var => 'post', b => 2});
 
         ok $res->{success}, 'req is success';
@@ -53,8 +56,9 @@ Test::TCP::test_tcp(
 
         set ( environment  => 'production',
               port         => $port,
-              server       => '127.0.0.10',
+              server       => $host,
               startup_info => 0);
         Dancer->dance();
     },
+    host => $host,
 );

--- a/t/02_request/13_ajax.t
+++ b/t/02_request/13_ajax.t
@@ -10,17 +10,19 @@ plan tests => 8;
 use HTTP::Tiny;
 use HTTP::Headers;
 
+my $host = '127.0.0.10';
+
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
         my $ua = HTTP::Tiny->new;
 
         my $headers = { 'X-Requested-With' => 'XMLHttpRequest' };
-        my $res = $ua->get("http://127.0.0.10:$port/req", { headers => $headers });
+        my $res = $ua->get("http://$host:$port/req", { headers => $headers });
         ok($res->{success}, "server responded");
         is($res->{content}, 1, "content ok");
 
-        $res = $ua->get("http://127.0.0.10:$port/req");
+        $res = $ua->get("http://$host:$port/req");
         ok($res->{success}, "server responded");
         is($res->{content}, 0, "content ok");
     },
@@ -28,7 +30,7 @@ Test::TCP::test_tcp(
         my $port = shift;
         use Dancer;
         set (port         => $port,
-             server       => '127.0.0.10',
+             server       => $host,
              startup_info => 0);
 
         get '/req' => sub {
@@ -36,6 +38,7 @@ Test::TCP::test_tcp(
         };
         Dancer->dance();
     },
+    host => $host,
 );
 
 # basic interface

--- a/t/02_request/13_ajax.t
+++ b/t/02_request/13_ajax.t
@@ -16,11 +16,11 @@ Test::TCP::test_tcp(
         my $ua = HTTP::Tiny->new;
 
         my $headers = { 'X-Requested-With' => 'XMLHttpRequest' };
-        my $res = $ua->get("http://127.0.0.1:$port/req", { headers => $headers });
+        my $res = $ua->get("http://127.0.0.10:$port/req", { headers => $headers });
         ok($res->{success}, "server responded");
         is($res->{content}, 1, "content ok");
 
-        $res = $ua->get("http://127.0.0.1:$port/req");
+        $res = $ua->get("http://127.0.0.10:$port/req");
         ok($res->{success}, "server responded");
         is($res->{content}, 0, "content ok");
     },
@@ -28,7 +28,7 @@ Test::TCP::test_tcp(
         my $port = shift;
         use Dancer;
         set (port         => $port,
-             server       => '127.0.0.1',
+             server       => '127.0.0.10',
              startup_info => 0);
 
         get '/req' => sub {

--- a/t/02_request/15_headers.t
+++ b/t/02_request/15_headers.t
@@ -24,7 +24,7 @@ Test::TCP::test_tcp(
 
         my $headers = { 'X-User-Head1' => 42, 'X-User-Head2' => 43 };
 
-        my $res = $ua->get("http://127.0.0.1:$port/req", { headers => $headers });
+        my $res = $ua->get("http://127.0.0.10:$port/req", { headers => $headers });
         ok($res->{success}, "$handler server responded");
         is($res->{headers}{'x-foo'}, 2);
         is($res->{headers}{'x-bar'}, 3);
@@ -36,7 +36,7 @@ Test::TCP::test_tcp(
 
         set( apphandler   => $handler,
              port         => $port,
-             server       => '127.0.0.1',
+             server       => '127.0.0.10',
              show_errors  => 1,
              startup_info => 0 );
 

--- a/t/02_request/15_headers.t
+++ b/t/02_request/15_headers.t
@@ -16,6 +16,8 @@ plan tests => $plack_available ? 12 : 6;
 my @handlers = ('Standalone');
 push @handlers, 'PSGI' if $plack_available;
 
+my $host = '127.0.0.10';
+
 for my $handler (@handlers) {
 Test::TCP::test_tcp(
     client => sub {
@@ -24,7 +26,7 @@ Test::TCP::test_tcp(
 
         my $headers = { 'X-User-Head1' => 42, 'X-User-Head2' => 43 };
 
-        my $res = $ua->get("http://127.0.0.10:$port/req", { headers => $headers });
+        my $res = $ua->get("http://$host:$port/req", { headers => $headers });
         ok($res->{success}, "$handler server responded");
         is($res->{headers}{'x-foo'}, 2);
         is($res->{headers}{'x-bar'}, 3);
@@ -36,7 +38,7 @@ Test::TCP::test_tcp(
 
         set( apphandler   => $handler,
              port         => $port,
-             server       => '127.0.0.10',
+             server       => $host,
              show_errors  => 1,
              startup_info => 0 );
 
@@ -62,5 +64,6 @@ Test::TCP::test_tcp(
             Dancer->dance();
         }
     },
+    host => $host,
 );
 }

--- a/t/03_route_handler/21_ajax.t
+++ b/t/03_route_handler/21_ajax.t
@@ -40,7 +40,7 @@ Test::TCP::test_tcp(
             $headers{'X-Requested-With'} = 'XMLHttpRequest'
               if ( $query->{ajax} == 1);
 
-            ok my $res = $ua->get("http://127.0.0.1:$port/" . $query->{path}, { headers => \%headers });
+            ok my $res = $ua->get("http://127.0.0.10:$port/" . $query->{path}, { headers => \%headers });
 
             if ( $query->{success} == 1) {
                 ok $res->{success};
@@ -54,7 +54,7 @@ Test::TCP::test_tcp(
 
         # test ajax with content_type to json
         my %headers = ( 'X-Requested-With' => 'XMLHttpRequest' );
-        ok my $res = $ua->get("http://127.0.0.1:$port/ajax.json", { headers => \%headers });
+        ok my $res = $ua->get("http://127.0.0.10:$port/ajax.json", { headers => \%headers });
         like $res->{headers}{'content-type'}, qr/json/;
     },
     server => sub {
@@ -63,7 +63,7 @@ Test::TCP::test_tcp(
         use Dancer;
         use Dancer::Plugin::Ajax;
 
-        set startup_info => 0, port => $port, server => '127.0.0.1', layout => 'wibble';
+        set startup_info => 0, port => $port, server => '127.0.0.10', layout => 'wibble';
 
         ajax '/req' => sub {
             return 1;

--- a/t/03_route_handler/21_ajax.t
+++ b/t/03_route_handler/21_ajax.t
@@ -12,6 +12,8 @@ use HTTP::Tiny;
 
 plan tests => 33;
 
+my $host = '127.0.0.10';
+
 ok(Dancer::App->current->registry->is_empty,
     "registry is empty");
 ok(Dancer::Plugin::Ajax::ajax( '/', sub { "ajax" } ), "ajax helper called");
@@ -40,7 +42,7 @@ Test::TCP::test_tcp(
             $headers{'X-Requested-With'} = 'XMLHttpRequest'
               if ( $query->{ajax} == 1);
 
-            ok my $res = $ua->get("http://127.0.0.10:$port/" . $query->{path}, { headers => \%headers });
+            ok my $res = $ua->get("http://$host:$port/" . $query->{path}, { headers => \%headers });
 
             if ( $query->{success} == 1) {
                 ok $res->{success};
@@ -54,7 +56,7 @@ Test::TCP::test_tcp(
 
         # test ajax with content_type to json
         my %headers = ( 'X-Requested-With' => 'XMLHttpRequest' );
-        ok my $res = $ua->get("http://127.0.0.10:$port/ajax.json", { headers => \%headers });
+        ok my $res = $ua->get("http://$host:$port/ajax.json", { headers => \%headers });
         like $res->{headers}{'content-type'}, qr/json/;
     },
     server => sub {
@@ -63,7 +65,7 @@ Test::TCP::test_tcp(
         use Dancer;
         use Dancer::Plugin::Ajax;
 
-        set startup_info => 0, port => $port, server => '127.0.0.10', layout => 'wibble';
+        set startup_info => 0, port => $port, server => $host, layout => 'wibble';
 
         ajax '/req' => sub {
             return 1;
@@ -92,4 +94,5 @@ Test::TCP::test_tcp(
         };
         start();
     },
+    host => $host,
 );

--- a/t/03_route_handler/28_plack_mount.t
+++ b/t/03_route_handler/28_plack_mount.t
@@ -21,7 +21,7 @@ plan tests => 3;
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
-        my $url = "http://127.0.0.1:$port/mount/test/foo";
+        my $url = "http://127.0.0.10:$port/mount/test/foo";
 
         my $ua = HTTP::Tiny->new();
         ok my $res = $ua->get($url);
@@ -48,7 +48,7 @@ Test::TCP::test_tcp(
         };
 
         my $server = HTTP::Server::Simple::PSGI->new($port);
-        $server->host("127.0.0.1");
+        $server->host("127.0.0.10");
         $server->app($app);
         $server->run;
     },

--- a/t/03_route_handler/28_plack_mount.t
+++ b/t/03_route_handler/28_plack_mount.t
@@ -18,10 +18,12 @@ use HTTP::Server::Simple::PSGI;
 
 plan tests => 3;
 
+my $host = '127.0.0.10';
+
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
-        my $url = "http://127.0.0.10:$port/mount/test/foo";
+        my $url = "http://$host:$port/mount/test/foo";
 
         my $ua = HTTP::Tiny->new();
         ok my $res = $ua->get($url);
@@ -48,8 +50,9 @@ Test::TCP::test_tcp(
         };
 
         my $server = HTTP::Server::Simple::PSGI->new($port);
-        $server->host("127.0.0.10");
+        $server->host($host);
         $server->app($app);
         $server->run;
     },
+    host => $host,
 );

--- a/t/03_route_handler/33_vars.t
+++ b/t/03_route_handler/33_vars.t
@@ -12,12 +12,15 @@ plan skip_all => "Test::TCP is needed for this test"
     unless Dancer::ModuleLoader->load("Test::TCP" => "1.30");
 
 plan tests => 10;
+
+my $host = '127.0.0.10';
+
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
         my $ua  = HTTP::Tiny->new;
         for (1..10) {
-            my $res = $ua->get("http://127.0.0.10:$port/getvarfoo");
+            my $res = $ua->get("http://$host:$port/getvarfoo");
             is $res->{content}, 1;
         }
     },
@@ -29,7 +32,7 @@ Test::TCP::test_tcp(
         # vars should be reset before the handler is called
         var foo => 42;
 
-        set startup_info => 0, port => $port, server => '127.0.0.10';
+        set startup_info => 0, port => $port, server => $host;
 
         get "/getvarfoo" => sub {
             return ++vars->{foo};
@@ -37,4 +40,5 @@ Test::TCP::test_tcp(
 
         Dancer->dance;
     },
+    host => $host,
 );

--- a/t/03_route_handler/33_vars.t
+++ b/t/03_route_handler/33_vars.t
@@ -17,7 +17,7 @@ Test::TCP::test_tcp(
         my $port = shift;
         my $ua  = HTTP::Tiny->new;
         for (1..10) {
-            my $res = $ua->get("http://127.0.0.1:$port/getvarfoo");
+            my $res = $ua->get("http://127.0.0.10:$port/getvarfoo");
             is $res->{content}, 1;
         }
     },
@@ -29,7 +29,7 @@ Test::TCP::test_tcp(
         # vars should be reset before the handler is called
         var foo => 42;
 
-        set startup_info => 0, port => $port, server => '127.0.0.1';
+        set startup_info => 0, port => $port, server => '127.0.0.10';
 
         get "/getvarfoo" => sub {
             return ++vars->{foo};

--- a/t/03_route_handler/34_forward_body_post.t
+++ b/t/03_route_handler/34_forward_body_post.t
@@ -22,7 +22,7 @@ plan tests => 2;
 Test::TCP::test_tcp(
   client => sub {
       my $port = shift;
-      my $url_base  = "http://127.0.0.1:$port";
+      my $url_base  = "http://127.0.0.10:$port";
       my $ua  = HTTP::Tiny->new;
       my $res = $ua->post_form($url_base . "/foo", { data => 'foo'});
       is($res->{content}, "data:foo");
@@ -41,7 +41,7 @@ Test::TCP::test_tcp(
 
       post '/foz' => sub { forward '/baz';  };
       post '/baz' => sub { join(":",params('body')) };
-      set startup_info => 0, port => $port, server => '127.0.0.1', show_errors  => 1;
+      set startup_info => 0, port => $port, server => '127.0.0.10', show_errors  => 1;
       Dancer->dance();
   },
                    );

--- a/t/03_route_handler/34_forward_body_post.t
+++ b/t/03_route_handler/34_forward_body_post.t
@@ -19,10 +19,12 @@ use HTTP::Tiny;
 
 plan tests => 2;
 
+my $host = '127.0.0.10';
+
 Test::TCP::test_tcp(
     client => sub {
         my $port     = shift;
-        my $url_base = "http://127.0.0.10:$port";
+        my $url_base = "http://$host:$port";
         my $ua       = HTTP::Tiny->new;
         my $res      = $ua->post_form($url_base . "/foo", {data => 'foo'});
         is($res->{content}, "data:foo");
@@ -45,9 +47,10 @@ Test::TCP::test_tcp(
         set
           startup_info => 0,
           port         => $port,
-          server       => '127.0.0.10',
+          server       => $host,
           show_errors  => 1;
         Dancer->dance();
     },
+    host => $host,
 );
 

--- a/t/03_route_handler/34_forward_body_post.t
+++ b/t/03_route_handler/34_forward_body_post.t
@@ -20,29 +20,34 @@ use HTTP::Tiny;
 plan tests => 2;
 
 Test::TCP::test_tcp(
-  client => sub {
-      my $port = shift;
-      my $url_base  = "http://127.0.0.10:$port";
-      my $ua  = HTTP::Tiny->new;
-      my $res = $ua->post_form($url_base . "/foo", { data => 'foo'});
-      is($res->{content}, "data:foo");
+    client => sub {
+        my $port     = shift;
+        my $url_base = "http://127.0.0.10:$port";
+        my $ua       = HTTP::Tiny->new;
+        my $res      = $ua->post_form($url_base . "/foo", {data => 'foo'});
+        is($res->{content}, "data:foo");
 
-      $res = $ua->post_form($url_base . "/foz", { data => 'foo'});
-      is($res->{content}, "data:foo");
-  },
-  server => sub {
-      my $port = shift;
-      Dancer::Config->load;
-      post '/foo' => sub {
-          forward '/bar';
-          fail "This line should not be executed - forward should have aborted the route execution";
-      };
-      post '/bar' => sub { join(":",params) };
+        $res = $ua->post_form($url_base . "/foz", {data => 'foo'});
+        is($res->{content}, "data:foo");
+    },
+    server => sub {
+        my $port = shift;
+        Dancer::Config->load;
+        post '/foo' => sub {
+            forward '/bar';
+            fail "This line should not be executed - "
+                . "forward should have aborted the route execution";
+        };
+        post '/bar' => sub { join(":", params) };
 
-      post '/foz' => sub { forward '/baz';  };
-      post '/baz' => sub { join(":",params('body')) };
-      set startup_info => 0, port => $port, server => '127.0.0.10', show_errors  => 1;
-      Dancer->dance();
-  },
-                   );
+        post '/foz' => sub { forward '/baz'; };
+        post '/baz' => sub { join(":", params('body')) };
+        set
+          startup_info => 0,
+          port         => $port,
+          server       => '127.0.0.10',
+          show_errors  => 1;
+        Dancer->dance();
+    },
+);
 

--- a/t/04_static_file/001_base.t
+++ b/t/04_static_file/001_base.t
@@ -45,11 +45,13 @@ is $r->content, 'Bad Request';
 
 require HTTP::Tiny;
 
+my $host = '127.0.0.10';
+
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
         my $ua  = HTTP::Tiny->new();
-        my $res = $ua->get("http://127.0.0.10:$port/hello%00.txt");
+        my $res = $ua->get("http://$host:$port/hello%00.txt");
         ok !$res->{success};
         is $res->{status}, 400;
     },
@@ -58,9 +60,10 @@ Test::TCP::test_tcp(
         setting apphandler => 'PSGI';
         Dancer::Config->load;
         my $app = Dancer::Handler->psgi_app;
-        Plack::Loader->auto( port => $port, host => '127.0.0.10' )->run($app);
+        Plack::Loader->auto( port => $port, host => $host )->run($app);
         Dancer->dance();
-    }
+    },
+    host => $host,
 );
 
 Test::TCP::test_tcp(
@@ -68,7 +71,7 @@ Test::TCP::test_tcp(
         my $port = shift;
         my $headers = { 'If-Modified-Since' => $date };
         my $ua  = HTTP::Tiny->new();
-        my $res = $ua->get("http://127.0.0.10:$port/hello.txt", { headers => $headers });
+        my $res = $ua->get("http://$host:$port/hello.txt", { headers => $headers });
         ok !$res->{success};
         is $res->{status}, 304;
     },
@@ -77,7 +80,8 @@ Test::TCP::test_tcp(
         setting apphandler => 'PSGI';
         Dancer::Config->load;
         my $app = Dancer::Handler->psgi_app;
-        Plack::Loader->auto( port => $port, host => '127.0.0.10' )->run($app);
+        Plack::Loader->auto( port => $port, host => $host )->run($app);
         Dancer->dance();
-    }
+    },
+    host => $host,
 );

--- a/t/04_static_file/001_base.t
+++ b/t/04_static_file/001_base.t
@@ -49,7 +49,7 @@ Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
         my $ua  = HTTP::Tiny->new();
-        my $res = $ua->get("http://127.0.0.1:$port/hello%00.txt");
+        my $res = $ua->get("http://127.0.0.10:$port/hello%00.txt");
         ok !$res->{success};
         is $res->{status}, 400;
     },
@@ -58,7 +58,7 @@ Test::TCP::test_tcp(
         setting apphandler => 'PSGI';
         Dancer::Config->load;
         my $app = Dancer::Handler->psgi_app;
-        Plack::Loader->auto( port => $port, host => '127.0.0.1' )->run($app);
+        Plack::Loader->auto( port => $port, host => '127.0.0.10' )->run($app);
         Dancer->dance();
     }
 );
@@ -68,7 +68,7 @@ Test::TCP::test_tcp(
         my $port = shift;
         my $headers = { 'If-Modified-Since' => $date };
         my $ua  = HTTP::Tiny->new();
-        my $res = $ua->get("http://127.0.0.1:$port/hello.txt", { headers => $headers });
+        my $res = $ua->get("http://127.0.0.10:$port/hello.txt", { headers => $headers });
         ok !$res->{success};
         is $res->{status}, 304;
     },
@@ -77,7 +77,7 @@ Test::TCP::test_tcp(
         setting apphandler => 'PSGI';
         Dancer::Config->load;
         my $app = Dancer::Handler->psgi_app;
-        Plack::Loader->auto( port => $port, host => '127.0.0.1' )->run($app);
+        Plack::Loader->auto( port => $port, host => '127.0.0.10' )->run($app);
         Dancer->dance();
     }
 );

--- a/t/07_apphandlers/02_apache2_plack.t
+++ b/t/07_apphandlers/02_apache2_plack.t
@@ -19,9 +19,9 @@ my $env = {};
 
 my $document_root = File::Spec->rel2abs('.');
 my $server_name = 'localhost.localdomain';
-my $remote_addr = '127.0.0.1';
+my $remote_addr = '127.0.0.10';
 my $server_admin = 'admin@domain.com';
-my $server_addr = '127.0.0.1';
+my $server_addr = '127.0.0.10';
 my $host_name = 'app.localdomain.com';
 
 # a / request

--- a/t/07_apphandlers/03_psgi_app.t
+++ b/t/07_apphandlers/03_psgi_app.t
@@ -22,15 +22,15 @@ Test::TCP::test_tcp(
         my $port = shift;
         my $ua = HTTP::Tiny->new;
 
-        my $res = $ua->get("http://127.0.0.1:$port/env");
+        my $res = $ua->get("http://127.0.0.10:$port/env");
         like $res->{content}, qr/psgi\.version/,
             'content looks good for /env';
 
-        $res = $ua->get("http://127.0.0.1:$port/name/bar");
+        $res = $ua->get("http://127.0.0.10:$port/name/bar");
         like $res->{content}, qr/Your name: bar/,
             'content looks good for /name/bar';
 
-        $res = $ua->get("http://127.0.0.1:$port/name/baz");
+        $res = $ua->get("http://127.0.0.10:$port/name/baz");
         like $res->{content}, qr/Your name: baz/,
             'content looks good for /name/baz';
     },
@@ -44,6 +44,6 @@ Test::TCP::test_tcp(
         set apphandler  => 'PSGI', environment => 'production';
         Dancer::Config->load;
 
-        Plack::Loader->auto(port => $port, server => '127.0.0.1')->run($app);
+        Plack::Loader->auto(port => $port, server => '127.0.0.10')->run($app);
     },
 );

--- a/t/07_apphandlers/04_standalone_app.t
+++ b/t/07_apphandlers/04_standalone_app.t
@@ -13,28 +13,30 @@ use HTTP::Tiny;
 
 plan tests => 6;
 
+my $host = '127.0.0.10';
+
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
         my $ua = HTTP::Tiny->new;
 
-        my $res = $ua->get("http://127.0.0.10:$port/env");
+        my $res = $ua->get("http://$host:$port/env");
         like $res->{content}, qr/PATH_INFO/, 'path info is found in response';
 
-        $res = $ua->get("http://127.0.0.10:$port/name/bar");
+        $res = $ua->get("http://$host:$port/name/bar");
         like $res->{content}, qr/Your name: bar/, 'name is found on a GET';
 
-        $res = $ua->get("http://127.0.0.10:$port/name/baz");
+        $res = $ua->get("http://$host:$port/name/baz");
         like $res->{content}, qr/Your name: baz/, 'name is found on a GET';
 
-        $res = $ua->post_form("http://127.0.0.10:$port/name", { name => "xxx" });
+        $res = $ua->post_form("http://$host:$port/name", { name => "xxx" });
         like $res->{content}, qr/Your name: xxx/, 'name is found on a POST';
 
         # we are already skipping under MSWin32 (check plan above)
-        $res = $ua->get("http://127.0.0.10:$port/issues/499/true");
+        $res = $ua->get("http://$host:$port/issues/499/true");
         is $res->{content}, "OK";
 
-        $res = $ua->get("http://127.0.0.10:$port/issues/499/false");
+        $res = $ua->get("http://$host:$port/issues/499/false");
         is $res->{content}, "OK";
     },
     server => sub {
@@ -50,4 +52,5 @@ Test::TCP::test_tcp(
              startup_info => 0 );
         Dancer->dance();
     },
+    host => $host,
 );

--- a/t/07_apphandlers/04_standalone_app.t
+++ b/t/07_apphandlers/04_standalone_app.t
@@ -18,23 +18,23 @@ Test::TCP::test_tcp(
         my $port = shift;
         my $ua = HTTP::Tiny->new;
 
-        my $res = $ua->get("http://127.0.0.1:$port/env");
+        my $res = $ua->get("http://127.0.0.10:$port/env");
         like $res->{content}, qr/PATH_INFO/, 'path info is found in response';
 
-        $res = $ua->get("http://127.0.0.1:$port/name/bar");
+        $res = $ua->get("http://127.0.0.10:$port/name/bar");
         like $res->{content}, qr/Your name: bar/, 'name is found on a GET';
 
-        $res = $ua->get("http://127.0.0.1:$port/name/baz");
+        $res = $ua->get("http://127.0.0.10:$port/name/baz");
         like $res->{content}, qr/Your name: baz/, 'name is found on a GET';
 
-        $res = $ua->post_form("http://127.0.0.1:$port/name", { name => "xxx" });
+        $res = $ua->post_form("http://127.0.0.10:$port/name", { name => "xxx" });
         like $res->{content}, qr/Your name: xxx/, 'name is found on a POST';
 
         # we are already skipping under MSWin32 (check plan above)
-        $res = $ua->get("http://127.0.0.1:$port/issues/499/true");
+        $res = $ua->get("http://127.0.0.10:$port/issues/499/true");
         is $res->{content}, "OK";
 
-        $res = $ua->get("http://127.0.0.1:$port/issues/499/false");
+        $res = $ua->get("http://127.0.0.10:$port/issues/499/false");
         is $res->{content}, "OK";
     },
     server => sub {
@@ -46,7 +46,7 @@ Test::TCP::test_tcp(
         use TestApp;
         Dancer::Config->load;
         set( port         => $port,
-             server       => '127.0.0.1',
+             server       => '127.0.0.10',
              startup_info => 0 );
         Dancer->dance();
     },

--- a/t/07_apphandlers/05_middlewares.t
+++ b/t/07_apphandlers/05_middlewares.t
@@ -28,7 +28,7 @@ foreach my $c (@$confs) {
             my $port = shift;
             my $ua   = HTTP::Tiny->new;
 
-            my $res = $ua->get("http://127.0.0.1:$port/");
+            my $res = $ua->get("http://127.0.0.10:$port/");
             ok $res;
             ok $res->{headers}{'x-runtime'};
         },
@@ -41,11 +41,11 @@ foreach my $c (@$confs) {
             set( environment       => 'production',
                  apphandler        => 'PSGI',
                  port              => $port,
-                 server            => '127.0.0.1',
+                 server            => '127.0.0.10',
                  startup_info      => 0,
                  plack_middlewares => $c->[0] );
             my $app = Dancer::Handler->get_handler()->dance;
-            Plack::Loader->auto( port => $port, server => '127.0.0.1' )->run($app);
+            Plack::Loader->auto( port => $port, server => '127.0.0.10' )->run($app);
         },
     );
 

--- a/t/07_apphandlers/07_middleware_map.t
+++ b/t/07_apphandlers/07_middleware_map.t
@@ -30,7 +30,7 @@ Test::TCP::test_tcp(
         my $ua   = HTTP::Tiny->new;
 
         foreach my $test (@tests) {
-            my $res = $ua->get("http://127.0.0.1:$port" . $test->{path});
+            my $res = $ua->get("http://127.0.0.10:$port" . $test->{path});
             ok $res;
             if ( $test->{runtime} ) {
                 ok $res->{headers}{'x-runtime'};
@@ -49,11 +49,11 @@ Test::TCP::test_tcp(
         set( environment           => 'production',
              apphandler            => 'PSGI',
              port                  => $port,
-             server                => '127.0.0.1',
+             server                => '127.0.0.10',
              startup_info          => 0,
              plack_middlewares_map => $confs );
 
         my $app = Dancer::Handler->get_handler()->dance;
-        Plack::Loader->auto( port => $port, server => '127.0.0.1' )->run($app);
+        Plack::Loader->auto( port => $port, server => '127.0.0.10' )->run($app);
     },
 );

--- a/t/08_session/03_http_requests.t
+++ b/t/08_session/03_http_requests.t
@@ -44,14 +44,14 @@ Test::TCP::test_tcp(
         foreach my $client (@clients) {
             my $ua = HTTP::Tiny->new(cookie_jar => HTTP::CookieJar->new);
 
-            my $res = $ua->get("http://127.0.0.1:$port/read_session");
+            my $res = $ua->get("http://127.0.0.10:$port/read_session");
             like $res->{content}, qr/name=''/, 
             "empty session for client $client";
 
-            $res = $ua->get("http://127.0.0.1:$port/set_session/$client");
+            $res = $ua->get("http://127.0.0.10:$port/set_session/$client");
             ok($res->{success}, "set_session for client $client");
 
-            $res = $ua->get("http://127.0.0.1:$port/read_session");
+            $res = $ua->get("http://127.0.0.10:$port/read_session");
             like $res->{content}, qr/name='$client'/,
             "session looks good for client $client";
 
@@ -72,7 +72,7 @@ Test::TCP::test_tcp(
              startup_info => 0,
              environment  => 'production',
              port         => $port,
-             server       => '127.0.0.1' );
+             server       => '127.0.0.10' );
         Dancer->dance();
     },
 );

--- a/t/08_session/03_http_requests.t
+++ b/t/08_session/03_http_requests.t
@@ -37,6 +37,8 @@ plan tests => 3 * scalar(@clients) * scalar(@engines) + (scalar(@engines));
 
 foreach my $engine (@engines) {
 
+my $host = '127.0.0.10';
+
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
@@ -44,14 +46,14 @@ Test::TCP::test_tcp(
         foreach my $client (@clients) {
             my $ua = HTTP::Tiny->new(cookie_jar => HTTP::CookieJar->new);
 
-            my $res = $ua->get("http://127.0.0.10:$port/read_session");
+            my $res = $ua->get("http://$host:$port/read_session");
             like $res->{content}, qr/name=''/, 
             "empty session for client $client";
 
-            $res = $ua->get("http://127.0.0.10:$port/set_session/$client");
+            $res = $ua->get("http://$host:$port/set_session/$client");
             ok($res->{success}, "set_session for client $client");
 
-            $res = $ua->get("http://127.0.0.10:$port/read_session");
+            $res = $ua->get("http://$host:$port/read_session");
             like $res->{content}, qr/name='$client'/,
             "session looks good for client $client";
 
@@ -68,13 +70,16 @@ Test::TCP::test_tcp(
         setting appdir => $tempdir;
         Dancer::Logger->init('File');
         ok(setting(session => $engine), "using engine $engine");
-        set( show_errors  => 1,
-             startup_info => 0,
-             environment  => 'production',
-             port         => $port,
-             server       => '127.0.0.10' );
+        set(
+            show_errors  => 1,
+            startup_info => 0,
+            environment  => 'production',
+            port         => $port,
+            server       => $host,
+        );
         Dancer->dance();
     },
+    host => $host,
 );
 }
 

--- a/t/08_session/07_session_expires.t
+++ b/t/08_session/07_session_expires.t
@@ -41,7 +41,7 @@ for my $session_expires (keys %tests) {
         client => sub {
             my $port = shift;
             my $ua   = HTTP::Tiny->new;
-            my $res = $ua->get("http://127.0.0.1:$port/set_session/test");
+            my $res = $ua->get("http://127.0.0.10:$port/set_session/test");
             ok $res->{success}, 'req is success';
             my $cookie = $res->{headers}{'set-cookie'};
             ok $cookie, 'cookie is set';
@@ -62,7 +62,7 @@ for my $session_expires (keys %tests) {
                  session_expires => $session_expires,
                  environment     => 'production',
                  port            => $port,
-                 server          => '127.0.0.1',
+                 server          => '127.0.0.10',
                  startup_info    => 0 );
             Dancer->dance();
         },

--- a/t/08_session/07_session_expires.t
+++ b/t/08_session/07_session_expires.t
@@ -37,11 +37,13 @@ for my $session_expires (keys %tests) {
 
     note "Translate from $session_expires";
 
+    my $host = '127.0.0.10';
+
     Test::TCP::test_tcp(
         client => sub {
             my $port = shift;
             my $ua   = HTTP::Tiny->new;
-            my $res = $ua->get("http://127.0.0.10:$port/set_session/test");
+            my $res = $ua->get("http://$host:$port/set_session/test");
             ok $res->{success}, 'req is success';
             my $cookie = $res->{headers}{'set-cookie'};
             ok $cookie, 'cookie is set';
@@ -62,10 +64,11 @@ for my $session_expires (keys %tests) {
                  session_expires => $session_expires,
                  environment     => 'production',
                  port            => $port,
-                 server          => '127.0.0.10',
+                 server          => $host,
                  startup_info    => 0 );
             Dancer->dance();
         },
+        host => $host,
     );
 }
 

--- a/t/08_session/13_session_httponly.t
+++ b/t/08_session/13_session_httponly.t
@@ -26,7 +26,7 @@ for my $setting ("default", "on", "off") {
         client => sub {
             my $port = shift;
             my $ua   = HTTP::Tiny->new;
-            my $res = $ua->get("http://127.0.0.1:$port/set_session/test_13");
+            my $res = $ua->get("http://127.0.0.10:$port/set_session/test_13");
             ok $res->{success}, 'req is success';
             my $cookie = $res->{headers}{'set-cookie'};
             ok $cookie, 'cookie is set';
@@ -55,7 +55,7 @@ for my $setting ("default", "on", "off") {
         }
         set( environment          => 'production',
              port                 => $port,
-             server               => '127.0.0.1',
+             server               => '127.0.0.10',
              startup_info         => 0 );
         Dancer->dance();
         },

--- a/t/08_session/13_session_httponly.t
+++ b/t/08_session/13_session_httponly.t
@@ -21,12 +21,14 @@ use Dancer::Config;
 my $session_dir = path( Dancer::Config::settings->{appdir}, "sessions_$$" );
 set session_dir => $session_dir;
 
+my $host = '127.0.0.10';
+
 for my $setting ("default", "on", "off") {
     Test::TCP::test_tcp(
         client => sub {
             my $port = shift;
             my $ua   = HTTP::Tiny->new;
-            my $res = $ua->get("http://127.0.0.10:$port/set_session/test_13");
+            my $res = $ua->get("http://$host:$port/set_session/test_13");
             ok $res->{success}, 'req is success';
             my $cookie = $res->{headers}{'set-cookie'};
             ok $cookie, 'cookie is set';
@@ -55,11 +57,12 @@ for my $setting ("default", "on", "off") {
         }
         set( environment          => 'production',
              port                 => $port,
-             server               => '127.0.0.10',
+             server               => $host,
              startup_info         => 0 );
         Dancer->dance();
-        },
-    );
+    },
+    host => $host,
+);
 
 }
 

--- a/t/09_cookies/03_persistence.t
+++ b/t/09_cookies/03_persistence.t
@@ -24,15 +24,15 @@ Test::TCP::test_tcp(
         foreach my $client (qw(one two three)) {
             my $ua = HTTP::Tiny->new(cookie_jar => HTTP::CookieJar->new);
 
-            my $res = $ua->get("http://127.0.0.1:$port/cookies");
+            my $res = $ua->get("http://127.0.0.10:$port/cookies");
             like $res->{content}, qr/\$VAR1 = \{\}/,
             "no cookies found for the client $client";
 
-            $res = $ua->get("http://127.0.0.1:$port/set_cookie/$client/42");
+            $res = $ua->get("http://127.0.0.10:$port/set_cookie/$client/42");
             # use YAML::Syck; warn Dump $res;
             ok($res->{success}, "set_cookie for client $client");
 
-            $res = $ua->get("http://127.0.0.1:$port/cookies");
+            $res = $ua->get("http://127.0.0.10:$port/cookies");
             like $res->{content}, qr/'name' => '$client'/,
             "cookie looks good for client $client";
         }
@@ -48,7 +48,7 @@ Test::TCP::test_tcp(
         set( startup_info => 0,
              environment  => 'production',
              port         => $port,
-             server       => '127.0.0.1' );
+             server       => '127.0.0.10' );
         Dancer->dance();
     },
 );

--- a/t/09_cookies/03_persistence.t
+++ b/t/09_cookies/03_persistence.t
@@ -17,6 +17,9 @@ use Dancer;
 use File::Spec;
 
 plan tests => 9;
+
+my $host = '127.0.0.10';
+
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
@@ -24,15 +27,15 @@ Test::TCP::test_tcp(
         foreach my $client (qw(one two three)) {
             my $ua = HTTP::Tiny->new(cookie_jar => HTTP::CookieJar->new);
 
-            my $res = $ua->get("http://127.0.0.10:$port/cookies");
+            my $res = $ua->get("http://$host:$port/cookies");
             like $res->{content}, qr/\$VAR1 = \{\}/,
             "no cookies found for the client $client";
 
-            $res = $ua->get("http://127.0.0.10:$port/set_cookie/$client/42");
+            $res = $ua->get("http://$host:$port/set_cookie/$client/42");
             # use YAML::Syck; warn Dump $res;
             ok($res->{success}, "set_cookie for client $client");
 
-            $res = $ua->get("http://127.0.0.10:$port/cookies");
+            $res = $ua->get("http://$host:$port/cookies");
             like $res->{content}, qr/'name' => '$client'/,
             "cookie looks good for client $client";
         }
@@ -45,10 +48,13 @@ Test::TCP::test_tcp(
         use TestApp;
         Dancer::Config->load;
 
-        set( startup_info => 0,
-             environment  => 'production',
-             port         => $port,
-             server       => '127.0.0.10' );
+        set(
+            startup_info => 0,
+            environment  => 'production',
+            port         => $port,
+            server       => $host,
+        );
         Dancer->dance();
     },
+    host => $host,
 );

--- a/t/12_response/04_charset_server.t
+++ b/t/12_response/04_charset_server.t
@@ -19,18 +19,20 @@ use HTTP::Tiny;
 
 plan tests => 10;
 
+my $host = '127.0.0.10';
+
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
         my $ua = HTTP::Tiny->new;
-        my $res = $ua->post_form("http://127.0.0.10:$port/name", [ name => 'vasya' ]);
+        my $res = $ua->post_form("http://$host:$port/name", [ name => 'vasya' ]);
 
         my $headers = HTTP::Headers->new(%{$res->{headers}});
         is $headers->content_type, 'text/html';
         ok $headers->content_type_charset; # we always have charset if the setting is set
         is $res->{content}, 'Your name: vasya';
 
-        $res = $ua->get("http://127.0.0.10:$port/unicode");
+        $res = $ua->get("http://$host:$port/unicode");
 
         $headers = HTTP::Headers->new(%{$res->{headers}});
         is $headers->content_type, 'text/html';
@@ -47,10 +49,11 @@ Test::TCP::test_tcp(
         set( charset      => 'utf-8',
              environment  => 'production',
              port         => $port,
-             server       => '127.0.0.10',
+             server       => $host,
              startup_info => 0 );
         Dancer->dance();
     },
+    host => $host,
 );
 
 Test::TCP::test_tcp(
@@ -58,7 +61,7 @@ Test::TCP::test_tcp(
         my $port = shift;
         my $ua = HTTP::Tiny->new;
 
-        my $res = $ua->get("http://127.0.0.10:$port/unicode-content-length");
+        my $res = $ua->get("http://$host:$port/unicode-content-length");
 
         my $headers = HTTP::Headers->new(%{$res->{headers}});
         is $headers->content_type, 'text/html';
@@ -78,11 +81,12 @@ Test::TCP::test_tcp(
             # no charset
             environment  => 'production',
             port         => $port,
-            server       => '127.0.0.10',
+            server       => $host,
             startup_info => 0,
         );
         Dancer->dance;
     },
+    host => $host,
 );
 
 SKIP: {
@@ -94,7 +98,7 @@ SKIP: {
             my $port = shift;
             my $ua = HTTP::Tiny->new;
 
-            my $res = $ua->get("http://127.0.0.10:$port/unicode-content-length-json");
+            my $res = $ua->get("http://$host:$port/unicode-content-length-json");
 
             my $headers = HTTP::Headers->new(%{$res->{headers}});
             is $headers->content_type, 'application/json';
@@ -111,12 +115,13 @@ SKIP: {
                 # no charset
                 environment  => 'production',
                 port         => $port,
-                server       => '127.0.0.10',
+                server       => $host,
                 startup_info => 0,
                 serializer   => 'JSON',
             );
             Dancer->dance;
         },
+        host => $host,
     );
 
 }

--- a/t/12_response/04_charset_server.t
+++ b/t/12_response/04_charset_server.t
@@ -23,14 +23,14 @@ Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
         my $ua = HTTP::Tiny->new;
-        my $res = $ua->post_form("http://127.0.0.1:$port/name", [ name => 'vasya' ]);
+        my $res = $ua->post_form("http://127.0.0.10:$port/name", [ name => 'vasya' ]);
 
         my $headers = HTTP::Headers->new(%{$res->{headers}});
         is $headers->content_type, 'text/html';
         ok $headers->content_type_charset; # we always have charset if the setting is set
         is $res->{content}, 'Your name: vasya';
 
-        $res = $ua->get("http://127.0.0.1:$port/unicode");
+        $res = $ua->get("http://127.0.0.10:$port/unicode");
 
         $headers = HTTP::Headers->new(%{$res->{headers}});
         is $headers->content_type, 'text/html';
@@ -47,7 +47,7 @@ Test::TCP::test_tcp(
         set( charset      => 'utf-8',
              environment  => 'production',
              port         => $port,
-             server       => '127.0.0.1',
+             server       => '127.0.0.10',
              startup_info => 0 );
         Dancer->dance();
     },
@@ -58,7 +58,7 @@ Test::TCP::test_tcp(
         my $port = shift;
         my $ua = HTTP::Tiny->new;
 
-        my $res = $ua->get("http://127.0.0.1:$port/unicode-content-length");
+        my $res = $ua->get("http://127.0.0.10:$port/unicode-content-length");
 
         my $headers = HTTP::Headers->new(%{$res->{headers}});
         is $headers->content_type, 'text/html';
@@ -78,7 +78,7 @@ Test::TCP::test_tcp(
             # no charset
             environment  => 'production',
             port         => $port,
-            server       => '127.0.0.1',
+            server       => '127.0.0.10',
             startup_info => 0,
         );
         Dancer->dance;
@@ -94,7 +94,7 @@ SKIP: {
             my $port = shift;
             my $ua = HTTP::Tiny->new;
 
-            my $res = $ua->get("http://127.0.0.1:$port/unicode-content-length-json");
+            my $res = $ua->get("http://127.0.0.10:$port/unicode-content-length-json");
 
             my $headers = HTTP::Headers->new(%{$res->{headers}});
             is $headers->content_type, 'application/json';
@@ -111,7 +111,7 @@ SKIP: {
                 # no charset
                 environment  => 'production',
                 port         => $port,
-                server       => '127.0.0.1',
+                server       => '127.0.0.10',
                 startup_info => 0,
                 serializer   => 'JSON',
             );

--- a/t/12_response/08_drop_content.t
+++ b/t/12_response/08_drop_content.t
@@ -18,10 +18,11 @@ use Dancer::Test;
 test();
 
 sub test {
+    my $host = '127.0.0.10';
     Test::TCP::test_tcp(
         client => sub {
             my $port = shift;
-            my $url  = "http://127.0.0.10:$port/";
+            my $url  = "http://$host:$port/";
 
             my $ua = HTTP::Tiny->new;
             for (qw/204 304/) {
@@ -32,7 +33,7 @@ sub test {
         },
         server => sub {
             my $port = shift;
-            set port => $port, server => '127.0.0.10', startup_info => 0;
+            set port => $port, server => $host, startup_info => 0;
 
             get '/204' => sub {
                 status 204;
@@ -45,6 +46,7 @@ sub test {
 
             Dancer->dance();
         },
+        host => $host,
     );
 }
 

--- a/t/12_response/08_drop_content.t
+++ b/t/12_response/08_drop_content.t
@@ -21,7 +21,7 @@ sub test {
     Test::TCP::test_tcp(
         client => sub {
             my $port = shift;
-            my $url  = "http://127.0.0.1:$port/";
+            my $url  = "http://127.0.0.10:$port/";
 
             my $ua = HTTP::Tiny->new;
             for (qw/204 304/) {
@@ -32,7 +32,7 @@ sub test {
         },
         server => sub {
             my $port = shift;
-            set port => $port, server => '127.0.0.1', startup_info => 0;
+            set port => $port, server => '127.0.0.10', startup_info => 0;
 
             get '/204' => sub {
                 status 204;

--- a/t/14_serializer/17_clear_serializer.t
+++ b/t/14_serializer/17_clear_serializer.t
@@ -17,13 +17,15 @@ set serializer => 'JSON';
 
 my $data = { foo => 'bar' };
 
+my $host = '127.0.0.10';
+
 Test::TCP::test_tcp(
     client => sub {
         my $port    = shift;
         my $ua      = HTTP::Tiny->new;
         my $res;
 
-        $res = $ua->get("http://127.0.0.10:$port/");
+        $res = $ua->get("http://$host:$port/");
         ok( $res->{success}, 'Successful response from server' );
         like(
             $res->{content},
@@ -32,7 +34,7 @@ Test::TCP::test_tcp(
         );
 
         # new request, no serializer
-        $res = $ua->get("http://127.0.0.10:$port/");
+        $res = $ua->get("http://$host:$port/");
         ok( $res->{success}, 'Successful response from server' );
         like($res->{content}, qr/HASH\(0x.+\)/,
             'Serializer undef, response not serialised');
@@ -44,7 +46,7 @@ Test::TCP::test_tcp(
 
         set( apphandler   => 'Standalone',
              port         => $port,
-             server       => '127.0.0.10',
+             server       => $host,
              show_errors  => 1,
              startup_info => 0 );
 
@@ -54,5 +56,6 @@ Test::TCP::test_tcp(
 
         Dancer->dance();
     },
+    host => $host,
 );
 

--- a/t/14_serializer/17_clear_serializer.t
+++ b/t/14_serializer/17_clear_serializer.t
@@ -23,7 +23,7 @@ Test::TCP::test_tcp(
         my $ua      = HTTP::Tiny->new;
         my $res;
 
-        $res = $ua->get("http://127.0.0.1:$port/");
+        $res = $ua->get("http://127.0.0.10:$port/");
         ok( $res->{success}, 'Successful response from server' );
         like(
             $res->{content},
@@ -32,7 +32,7 @@ Test::TCP::test_tcp(
         );
 
         # new request, no serializer
-        $res = $ua->get("http://127.0.0.1:$port/");
+        $res = $ua->get("http://127.0.0.10:$port/");
         ok( $res->{success}, 'Successful response from server' );
         like($res->{content}, qr/HASH\(0x.+\)/,
             'Serializer undef, response not serialised');
@@ -44,7 +44,7 @@ Test::TCP::test_tcp(
 
         set( apphandler   => 'Standalone',
              port         => $port,
-             server       => '127.0.0.1',
+             server       => '127.0.0.10',
              show_errors  => 1,
              startup_info => 0 );
 

--- a/t/15_plugins/07_ajax_plack_builder.t
+++ b/t/15_plugins/07_ajax_plack_builder.t
@@ -30,7 +30,7 @@ my $js_content = q[<script type="text/javascript">
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
-        my $url  = "http://127.0.0.1:$port/";
+        my $url  = "http://127.0.0.10:$port/";
 
         my $ua  = HTTP::Tiny->new();
 
@@ -50,7 +50,7 @@ Test::TCP::test_tcp(
         my $handler = sub {
             use Dancer;
 
-            set port => $port, server => '127.0.0.1', apphandler => 'PSGI', startup_info => 0;
+            set port => $port, server => '127.0.0.10', apphandler => 'PSGI', startup_info => 0;
 
             get  '/'    => sub {$js_content};
             ajax '/foo' => sub {'bar'};
@@ -65,7 +65,7 @@ Test::TCP::test_tcp(
         };
 
         my $server = HTTP::Server::Simple::PSGI->new($port);
-        $server->host("127.0.0.1");
+        $server->host("127.0.0.10");
         $server->app($app);
         $server->run;
     },

--- a/t/15_plugins/07_ajax_plack_builder.t
+++ b/t/15_plugins/07_ajax_plack_builder.t
@@ -19,6 +19,8 @@ use HTTP::Server::Simple::PSGI;
 
 plan tests => 6;
 
+my $host = '127.0.0.10';
+
 my $js_content = q[<script type="text/javascript">
     var xhr = new XMLHttpRequest();
     xhr.open( 'POST', '/foo' );
@@ -30,7 +32,7 @@ my $js_content = q[<script type="text/javascript">
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
-        my $url  = "http://127.0.0.10:$port/";
+        my $url  = "http://$host:$port/";
 
         my $ua  = HTTP::Tiny->new();
 
@@ -50,7 +52,7 @@ Test::TCP::test_tcp(
         my $handler = sub {
             use Dancer;
 
-            set port => $port, server => '127.0.0.10', apphandler => 'PSGI', startup_info => 0;
+            set port => $port, server => $host, apphandler => 'PSGI', startup_info => 0;
 
             get  '/'    => sub {$js_content};
             ajax '/foo' => sub {'bar'};
@@ -65,9 +67,10 @@ Test::TCP::test_tcp(
         };
 
         my $server = HTTP::Server::Simple::PSGI->new($port);
-        $server->host("127.0.0.10");
+        $server->host($host);
         $server->app($app);
         $server->run;
     },
+    host => $host,
 );
 

--- a/t/21_dependents/Dancer-Session-Cookie.t
+++ b/t/21_dependents/Dancer-Session-Cookie.t
@@ -19,6 +19,7 @@ Test::TCP->import;
 
 plan tests=> 7;
 
+my $host = '127.0.0.10';
 test_tcp(
     client => sub {
         my $port = shift;
@@ -33,18 +34,18 @@ test_tcp(
         for my $jar (@jars) {
             $ua->cookie_jar( $jar );
 
-            my $res = $ua->get("http://0.0:$port/foo");
+            my $res = $ua->get("http://$host:$port/foo");
             is $res->{content}, "hits: 0, last_hit: ";
 
-            $res = $ua->get("http://0.0:$port/bar");
+            $res = $ua->get("http://$host:$port/bar");
             is $res->{content}, "hits: 1, last_hit: foo";
 
-            $res = $ua->get("http://0.0:$port/baz");
+            $res = $ua->get("http://$host:$port/baz");
             is $res->{content}, "hits: 2, last_hit: bar";
         }
 
         $ua->cookie_jar($jars[0]);
-        my $res = $ua->get("http://0.0:$port/wibble");
+        my $res = $ua->get("http://$host:$port/wibble");
         is $res->{content}, "hits: 3, last_hit: baz", "session not overwritten";
     },
     server => sub {
@@ -53,7 +54,7 @@ test_tcp(
         use Dancer ':tests';
 
         set( port                => $port,
-             server              => '127.0.0.10',
+             server              => $host,
              appdir              => '',          # quiet warnings not having an appdir
              startup_info        => 0,           # quiet startup banner
              session_cookie_key  => "John has a long mustache",
@@ -70,5 +71,6 @@ test_tcp(
         };
 
         dance;
-    }
+    },
+    host => $host,
 );

--- a/t/21_dependents/Dancer-Session-Cookie.t
+++ b/t/21_dependents/Dancer-Session-Cookie.t
@@ -53,7 +53,7 @@ test_tcp(
         use Dancer ':tests';
 
         set( port                => $port,
-             server              => '127.0.0.1',
+             server              => '127.0.0.10',
              appdir              => '',          # quiet warnings not having an appdir
              startup_info        => 0,           # quiet startup banner
              session_cookie_key  => "John has a long mustache",

--- a/t/24_deployment/01_multi_webapp.t
+++ b/t/24_deployment/01_multi_webapp.t
@@ -26,7 +26,7 @@ Test::TCP::test_tcp(
         my $ua = HTTP::Tiny->new();
         for(1..100){
             my $app = $apps[int(rand(scalar @apps - 1))];
-            my $res = $ua->get("http://127.0.0.1:$port/$app");
+            my $res = $ua->get("http://127.0.0.10:$port/$app");
             like $res->{content}, qr/Hello $app/;
         }
     },
@@ -55,7 +55,7 @@ Test::TCP::test_tcp(
         };
 
         my $server = HTTP::Server::Simple::PSGI->new($port);
-        $server->host("127.0.0.1");
+        $server->host("127.0.0.10");
         $server->app($app);
         $server->run;
     },

--- a/t/24_deployment/01_multi_webapp.t
+++ b/t/24_deployment/01_multi_webapp.t
@@ -18,6 +18,8 @@ use HTTP::Server::Simple::PSGI;
 
 plan tests => 100;
 
+my $host = '127.0.0.10';
+
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
@@ -26,7 +28,7 @@ Test::TCP::test_tcp(
         my $ua = HTTP::Tiny->new();
         for(1..100){
             my $app = $apps[int(rand(scalar @apps - 1))];
-            my $res = $ua->get("http://127.0.0.10:$port/$app");
+            my $res = $ua->get("http://$host:$port/$app");
             like $res->{content}, qr/Hello $app/;
         }
     },
@@ -55,8 +57,9 @@ Test::TCP::test_tcp(
         };
 
         my $server = HTTP::Server::Simple::PSGI->new($port);
-        $server->host("127.0.0.10");
+        $server->host($host);
         $server->app($app);
         $server->run;
     },
+    host => $host,
 );


### PR DESCRIPTION
This should help alleviate the problems we see on Travis and some smokers, where a race condition means that a port on 127.0.0.1 is available when first checked but taken by something else by the time our test server goes to listen on it.

Mostly fixes RT #102145: https://rt.cpan.org/Public/Bug/Display.html?id=102145

This is a somewhat half-assed approach, as it doesn't actually solve the race condition - just makes it much less likely by binding to a port on 127.0.0.10 instead of 127.0.0.1.  Hopefully that will be sufficient. It's still possible perhaps though that two Travis builds on different Perl versions at the same time could affect each other, though, so may need further thought.

The alternative, binning half the Test::TCP-driven stuff etc, is a lot more work, and probably unlikely to happen.
