### PR TITLE
Avoid warning with non-present optional megasplat.

### DIFF
--- a/lib/Dancer/Route.pm
+++ b/lib/Dancer/Route.pm
@@ -133,7 +133,7 @@ sub match {
 
             # megasplat values are split on '/'
             if ($token_or_splat[$i] eq 'megasplat') {
-                $values[$i] = [ split '/' => $values[$i] ];
+                $values[$i] = [ split '/', $values[$i] || '' ];
             }
             push @splat, $values[$i];
         }


### PR DESCRIPTION
This fixes issue #1144.

If you had a route with an optional megasplat, for example:

```perl
get '/foo/?**?' => sub { ... };
```

and you called it as `/foo`, you'd get a warning:

```
Use of uninitialized value $values[0] in split at
/home/davidp/dev/github/Dancer/lib/Dancer/Route.pm line 136.
```

This fixes it.  However you will still get an empty arrayref.  Part of me would
prefer it return undef instead of an empty arrayref in this case, but that would
be changing existing behaviour which apps in the wild may be relying upon, so
it' probably safest to maintain the same behaviour and just squash the warning.