### PR TITLE
Issue 1140: bundle "fixed" HTTP::Body

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,4 @@ install:
 sudo: false
 
 script:
-    - dzil test --author --release
+    - dzil smoke --author --release

--- a/Changes
+++ b/Changes
@@ -12,6 +12,8 @@ Revision history for Dancer
    by using 127.0.0.10 instead (more of a hacky workaround than a fix, but
    should help (bigpresh)
  - Fix YAML session handler under taint mode (chrisjrob)
+ - Make request->body work again for URL-encoded POST requests - Issue 1140
+   reported by miyagawa (bigpresh)
 
  [DOCUMENTATION]
  - Better doc for forward_for_address (PR 1146, Relequestual)

--- a/MANIFEST
+++ b/MANIFEST
@@ -162,6 +162,7 @@ t/02_request/16_delete.t
 t/02_request/17_uri_base.t
 t/02_request/18_param_accessor.t
 t/02_request/19_json_body.t
+t/02_request/20_body.t
 t/03_route_handler/01_http_methods.t
 t/03_route_handler/02_params.t
 t/03_route_handler/03_routes_api.t

--- a/MANIFEST
+++ b/MANIFEST
@@ -46,6 +46,12 @@ lib/Dancer/Factory/Hook.pm
 lib/Dancer/FileUtils.pm
 lib/Dancer/GetOpt.pm
 lib/Dancer/HTTP.pm
+lib/Dancer/HTTP/Body.pm
+lib/Dancer/HTTP/Body/MultiPart.pm
+lib/Dancer/HTTP/Body/OctetStream.pm
+lib/Dancer/HTTP/Body/UrlEncoded.pm
+lib/Dancer/HTTP/Body/XForms.pm
+lib/Dancer/HTTP/Body/XFormsMultipart.pm
 lib/Dancer/Handler.pm
 lib/Dancer/Handler/Debug.pm
 lib/Dancer/Handler/PSGI.pm

--- a/dist.ini
+++ b/dist.ini
@@ -32,4 +32,8 @@ HTTP::Tiny = 0.014 ; for get/post/post_form
 HTTP::CookieJar = 0.008
 Test::TCP = 2.08 ; version that started supporting bind host
 
+[MetaNoIndex]
+; Don't let PAUSE index the shipped version of HTTP::Body
+directory = lib/Dancer/HTTP
+
 ; authordep Dist::Zilla::Plugin::Test::ReportPrereqs

--- a/lib/Dancer.pm
+++ b/lib/Dancer.pm
@@ -1964,8 +1964,6 @@ The following modules are mandatory (Dancer cannot run without them):
 
 =item L<HTTP::Server::Simple::PSGI>
 
-=item L<HTTP::Body>
-
 =item L<HTTP::Tiny>
 
 =item L<MIME::Types>

--- a/lib/Dancer/HTTP/Body.pm
+++ b/lib/Dancer/HTTP/Body.pm
@@ -1,0 +1,490 @@
+package Dancer::HTTP::Body;
+
+use strict;
+
+use Carp       qw[ ];
+
+our $TYPES = {
+    'application/octet-stream'          => 'Dancer::HTTP::Body::OctetStream',
+    'application/x-www-form-urlencoded' => 'Dancer::HTTP::Body::UrlEncoded',
+    'multipart/form-data'               => 'Dancer::HTTP::Body::MultiPart',
+    'multipart/related'                 => 'Dancer::HTTP::Body::XFormsMultipart',
+    'application/xml'                   => 'Dancer::HTTP::Body::XForms',
+    'application/json'                  => 'Dancer::HTTP::Body::OctetStream',
+};
+
+require Dancer::HTTP::Body::OctetStream;
+require Dancer::HTTP::Body::UrlEncoded;
+require Dancer::HTTP::Body::MultiPart;
+require Dancer::HTTP::Body::XFormsMultipart;
+require Dancer::HTTP::Body::XForms;
+
+use HTTP::Headers;
+use HTTP::Message;
+
+=head1 NAME
+
+Dancer::HTTP::Body - HTTP Body Parser
+
+=head1 SYNOPSIS
+
+    use Dancer::HTTP::Body;
+    
+    sub handler : method {
+        my ( $class, $r ) = @_;
+
+        my $content_type   = $r->headers_in->get('Content-Type');
+        my $content_length = $r->headers_in->get('Content-Length');
+        
+        my $body   = Dancer::HTTP::Body->new( $content_type, $content_length );
+        my $length = $content_length;
+
+        while ( $length ) {
+
+            $r->read( my $buffer, ( $length < 8192 ) ? $length : 8192 );
+
+            $length -= length($buffer);
+            
+            $body->add($buffer);
+        }
+        
+        my $uploads     = $body->upload;     # hashref
+        my $params      = $body->param;      # hashref
+        my $param_order = $body->param_order # arrayref
+        my $body        = $body->body;       # IO::Handle
+    }
+
+=head1 DESCRIPTION
+
+Dancer::HTTP::Body parses chunks of HTTP POST data and supports
+application/octet-stream, application/json, application/x-www-form-urlencoded,
+and multipart/form-data.
+
+Chunked bodies are supported by not passing a length value to new().
+
+It is currently used by L<Catalyst> to parse POST bodies.
+
+=head1 NOTES
+
+When parsing multipart bodies, temporary files are created to store any
+uploaded files.  You must delete these temporary files yourself after
+processing them, or set $body->cleanup(1) to automatically delete them
+at DESTROY-time.
+
+=head1 METHODS
+
+=over 4 
+
+=item new 
+
+Constructor. Takes content type and content length as parameters,
+returns a L<Dancer::HTTP::Body> object.
+
+=cut
+
+sub new {
+    my ( $class, $content_type, $content_length ) = @_;
+
+    unless ( @_ >= 2 ) {
+        Carp::croak( $class, '->new( $content_type, [ $content_length ] )' );
+    }
+
+    my $type;
+    my $earliest_index;
+    foreach my $supported ( keys %{$TYPES} ) {
+        my $index = index( lc($content_type), $supported );
+        if ($index >= 0 && (!defined $earliest_index || $index < $earliest_index)) {
+            $type           = $supported;
+            $earliest_index = $index;
+        }
+    }
+
+    my $body = $TYPES->{ $type || 'application/octet-stream' };
+
+    my $self = {
+        cleanup        => 0,
+        buffer         => '',
+        chunk_buffer   => '',
+        body           => undef,
+        chunked        => !defined $content_length,
+        content_length => defined $content_length ? $content_length : -1,
+        content_type   => $content_type,
+        length         => 0,
+        param          => {},
+        param_order    => [],
+        state          => 'buffering',
+        upload         => {},
+        part_data      => {},
+        tmpdir         => File::Spec->tmpdir(),
+    };
+
+    bless( $self, $body );
+
+    return $self->init;
+}
+
+sub DESTROY {
+    my $self = shift;
+    
+    if ( $self->{cleanup} ) {
+        my @temps = ();
+        for my $upload ( values %{ $self->{upload} } ) {
+            push @temps, map { $_->{tempname} || () }
+                ( ref $upload eq 'ARRAY' ? @{$upload} : $upload );
+        }
+        
+        unlink map { $_ } grep { -e $_ } @temps;
+    }
+}
+
+=item add
+
+Add string to internal buffer. Will call spin unless done. returns
+length before adding self.
+
+=cut
+
+sub add {
+    my $self = shift;
+    
+    if ( $self->{chunked} ) {
+        $self->{chunk_buffer} .= $_[0];
+        
+        while ( $self->{chunk_buffer} =~ m/^([\da-fA-F]+).*\x0D\x0A/ ) {
+            my $chunk_len = hex($1);
+            
+            if ( $chunk_len == 0 ) {
+                # Strip chunk len
+                $self->{chunk_buffer} =~ s/^([\da-fA-F]+).*\x0D\x0A//;
+                
+                # End of data, there may be trailing headers
+                if (  my ($headers) = $self->{chunk_buffer} =~ m/(.*)\x0D\x0A/s ) {
+                    if ( my $message = HTTP::Message->parse( $headers ) ) {
+                        $self->{trailing_headers} = $message->headers;
+                    }
+                }
+                
+                $self->{chunk_buffer} = '';
+                
+                # Set content_length equal to the amount of data we read,
+                # so the spin methods can finish up.
+                $self->{content_length} = $self->{length};
+            }
+            else {
+                # Make sure we have the whole chunk in the buffer (+CRLF)
+                if ( length( $self->{chunk_buffer} ) >= $chunk_len ) {
+                    # Strip chunk len
+                    $self->{chunk_buffer} =~ s/^([\da-fA-F]+).*\x0D\x0A//;
+                    
+                    # Pull chunk data out of chunk buffer into real buffer
+                    $self->{buffer} .= substr $self->{chunk_buffer}, 0, $chunk_len, '';
+                
+                    # Strip remaining CRLF
+                    $self->{chunk_buffer} =~ s/^\x0D\x0A//;
+                
+                    $self->{length} += $chunk_len;
+                }
+                else {
+                    # Not enough data for this chunk, wait for more calls to add()
+                    return;
+                }
+            }
+            
+            unless ( $self->{state} eq 'done' ) {
+                $self->spin;
+            }
+        }
+        
+        return;
+    }
+    
+    my $cl = $self->content_length;
+
+    if ( defined $_[0] ) {
+        $self->{length} += length( $_[0] );
+        
+        # Don't allow buffer data to exceed content-length
+        if ( $self->{length} > $cl ) {
+            $_[0] = substr $_[0], 0, $cl - $self->{length};
+            $self->{length} = $cl;
+        }
+        
+        $self->{buffer} .= $_[0];
+    }
+
+    unless ( $self->state eq 'done' ) {
+        $self->spin;
+    }
+
+    return ( $self->length - $cl );
+}
+
+=item body
+
+accessor for the body.
+
+=cut
+
+sub body {
+    my $self = shift;
+    $self->{body} = shift if @_;
+    return $self->{body};
+}
+
+=item chunked
+
+Returns 1 if the request is chunked.
+
+=cut
+
+sub chunked {
+    return shift->{chunked};
+}
+
+=item cleanup
+
+Set to 1 to enable automatic deletion of temporary files at DESTROY-time.
+
+=cut
+
+sub cleanup {
+    my $self = shift;
+    $self->{cleanup} = shift if @_;
+    return $self->{cleanup};
+}
+
+=item content_length
+
+Returns the content-length for the body data if known.
+Returns -1 if the request is chunked.
+
+=cut
+
+sub content_length {
+    return shift->{content_length};
+}
+
+=item content_type
+
+Returns the content-type of the body data.
+
+=cut
+
+sub content_type {
+    return shift->{content_type};
+}
+
+=item init
+
+return self.
+
+=cut
+
+sub init {
+    return $_[0];
+}
+
+=item length
+
+Returns the total length of data we expect to read if known.
+In the case of a chunked request, returns the amount of data
+read so far.
+
+=cut
+
+sub length {
+    return shift->{length};
+}
+
+=item trailing_headers
+
+If a chunked request body had trailing headers, trailing_headers will
+return an HTTP::Headers object populated with those headers.
+
+=cut
+
+sub trailing_headers {
+    return shift->{trailing_headers};
+}
+
+=item spin
+
+Abstract method to spin the io handle.
+
+=cut
+
+sub spin {
+    Carp::croak('Define abstract method spin() in implementation');
+}
+
+=item state
+
+Returns the current state of the parser.
+
+=cut
+
+sub state {
+    my $self = shift;
+    $self->{state} = shift if @_;
+    return $self->{state};
+}
+
+=item param
+
+Get/set body parameters.
+
+=cut
+
+sub param {
+    my $self = shift;
+
+    if ( @_ == 2 ) {
+
+        my ( $name, $value ) = @_;
+
+        if ( exists $self->{param}->{$name} ) {
+            for ( $self->{param}->{$name} ) {
+                $_ = [$_] unless ref($_) eq "ARRAY";
+                push( @$_, $value );
+            }
+        }
+        else {
+            $self->{param}->{$name} = $value;
+        }
+
+        push @{$self->{param_order}}, $name;
+    }
+
+    return $self->{param};
+}
+
+=item upload
+
+Get/set file uploads.
+
+=cut
+
+sub upload {
+    my $self = shift;
+
+    if ( @_ == 2 ) {
+
+        my ( $name, $upload ) = @_;
+
+        if ( exists $self->{upload}->{$name} ) {
+            for ( $self->{upload}->{$name} ) {
+                $_ = [$_] unless ref($_) eq "ARRAY";
+                push( @$_, $upload );
+            }
+        }
+        else {
+            $self->{upload}->{$name} = $upload;
+        }
+    }
+
+    return $self->{upload};
+}
+
+=item part_data
+
+Just like 'param' but gives you a hash of the full data associated with the
+part in a multipart type POST/PUT.  Example:
+
+    {
+      data => "test",
+      done => 1,
+      headers => {
+        "Content-Disposition" => "form-data; name=\"arg2\"",
+        "Content-Type" => "text/plain"
+      },
+      name => "arg2",
+      size => 4
+    }
+
+=cut
+
+sub part_data {
+    my $self = shift;
+
+    if ( @_ == 2 ) {
+
+        my ( $name, $data ) = @_;
+
+        if ( exists $self->{part_data}->{$name} ) {
+            for ( $self->{part_data}->{$name} ) {
+                $_ = [$_] unless ref($_) eq "ARRAY";
+                push( @$_, $data );
+            }
+        }
+        else {
+            $self->{part_data}->{$name} = $data;
+        }
+    }
+
+    return $self->{part_data};
+}
+
+=item tmpdir 
+
+Specify a different path for temporary files.  Defaults to the system temporary path.
+
+=cut
+
+sub tmpdir {
+    my $self = shift;
+    $self->{tmpdir} = shift if @_;
+    return $self->{tmpdir};
+}
+
+=item param_order
+
+Returns the array ref of the param keys in the order how they appeared on the body
+
+=cut
+
+sub param_order {
+    return shift->{param_order};
+}
+
+=back
+
+=head1 SUPPORT
+
+Since its original creation this module has been taken over by the Catalyst
+development team. If you want to contribute patches, these will be your
+primary contact points:
+
+IRC:
+
+    Join #catalyst-dev on irc.perl.org.
+
+Mailing Lists:
+
+    http://lists.scsys.co.uk/cgi-bin/mailman/listinfo/catalyst-dev
+
+=head1 AUTHOR
+
+Christian Hansen, C<chansen@cpan.org>
+
+Sebastian Riedel, C<sri@cpan.org>
+
+Andy Grundman, C<andy@hybridized.org>
+
+=head1 CONTRIBUTORS
+
+Simon Elliott C<cpan@papercreatures.com>
+
+Kent Fredric <kentnl@cpan.org>
+
+Christian Walde
+
+Torsten Raudssus <torsten@raudssus.de>
+
+=head1 LICENSE
+
+This library is free software. You can redistribute it and/or modify 
+it under the same terms as perl itself.
+
+=cut
+
+1;

--- a/lib/Dancer/HTTP/Body/MultiPart.pm
+++ b/lib/Dancer/HTTP/Body/MultiPart.pm
@@ -1,0 +1,325 @@
+package Dancer::HTTP::Body::MultiPart;
+
+use strict;
+use base 'Dancer::HTTP::Body';
+use bytes;
+
+use IO::File;
+use File::Temp 0.14;
+use File::Spec;
+
+=head1 NAME
+
+Dancer::HTTP::Body::MultiPart - HTTP Body Multipart Parser
+
+=head1 SYNOPSIS
+
+    use Dancer::HTTP::Body::MultiPart;
+
+=head1 DESCRIPTION
+
+HTTP Body Multipart Parser.
+
+=head1 METHODS
+
+=over 4
+
+=item init
+
+=cut
+
+sub init {
+    my $self = shift;
+
+    unless ( $self->content_type =~ /boundary=\"?([^\";]+)\"?/ ) {
+        my $content_type = $self->content_type;
+        Carp::croak("Invalid boundary in content_type: '$content_type'");
+    }
+
+    $self->{boundary} = $1;
+    $self->{state}    = 'preamble';
+
+    return $self;
+}
+
+=item spin
+
+=cut
+
+sub spin {
+    my $self = shift;
+
+    while (1) {
+
+        if ( $self->{state} =~ /^(preamble|boundary|header|body)$/ ) {
+            my $method = "parse_$1";
+            return unless $self->$method;
+        }
+
+        else {
+            Carp::croak('Unknown state');
+        }
+    }
+}
+
+=item boundary
+
+=cut
+
+sub boundary {
+    return shift->{boundary};
+}
+
+=item boundary_begin
+
+=cut
+
+sub boundary_begin {
+    return "--" . shift->boundary;
+}
+
+=item boundary_end
+
+=cut
+
+sub boundary_end {
+    return shift->boundary_begin . "--";
+}
+
+=item crlf
+
+=cut
+
+sub crlf () {
+    return "\x0d\x0a";
+}
+
+=item delimiter_begin
+
+=cut
+
+sub delimiter_begin {
+    my $self = shift;
+    return $self->crlf . $self->boundary_begin;
+}
+
+=item delimiter_end
+
+=cut
+
+sub delimiter_end {
+    my $self = shift;
+    return $self->crlf . $self->boundary_end;
+}
+
+=item parse_preamble
+
+=cut
+
+sub parse_preamble {
+    my $self = shift;
+
+    my $index = index( $self->{buffer}, $self->boundary_begin );
+
+    unless ( $index >= 0 ) {
+        return 0;
+    }
+
+    # replace preamble with CRLF so we can match dash-boundary as delimiter
+    substr( $self->{buffer}, 0, $index, $self->crlf );
+
+    $self->{state} = 'boundary';
+
+    return 1;
+}
+
+=item parse_boundary
+
+=cut
+
+sub parse_boundary {
+    my $self = shift;
+
+    if ( index( $self->{buffer}, $self->delimiter_begin . $self->crlf ) == 0 ) {
+
+        substr( $self->{buffer}, 0, length( $self->delimiter_begin ) + 2, '' );
+        $self->{part}  = {};
+        $self->{state} = 'header';
+
+        return 1;
+    }
+
+    if ( index( $self->{buffer}, $self->delimiter_end . $self->crlf ) == 0 ) {
+
+        substr( $self->{buffer}, 0, length( $self->delimiter_end ) + 2, '' );
+        $self->{part}  = {};
+        $self->{state} = 'done';
+
+        return 0;
+    }
+
+    return 0;
+}
+
+=item parse_header
+
+=cut
+
+sub parse_header {
+    my $self = shift;
+
+    my $crlf  = $self->crlf;
+    my $index = index( $self->{buffer}, $crlf . $crlf );
+
+    unless ( $index >= 0 ) {
+        return 0;
+    }
+
+    my $header = substr( $self->{buffer}, 0, $index );
+
+    substr( $self->{buffer}, 0, $index + 4, '' );
+
+    my @headers;
+    for ( split /$crlf/, $header ) {
+        if (s/^[ \t]+//) {
+            $headers[-1] .= $_;
+        }
+        else {
+            push @headers, $_;
+        }
+    }
+
+    my $token = qr/[^][\x00-\x1f\x7f()<>@,;:\\"\/?={} \t]+/;
+
+    for my $header (@headers) {
+
+        $header =~ s/^($token):[\t ]*//;
+
+        ( my $field = $1 ) =~ s/\b(\w)/uc($1)/eg;
+
+        if ( exists $self->{part}->{headers}->{$field} ) {
+            for ( $self->{part}->{headers}->{$field} ) {
+                $_ = [$_] unless ref($_) eq "ARRAY";
+                push( @$_, $header );
+            }
+        }
+        else {
+            $self->{part}->{headers}->{$field} = $header;
+        }
+    }
+
+    $self->{state} = 'body';
+
+    return 1;
+}
+
+=item parse_body
+
+=cut
+
+sub parse_body {
+    my $self = shift;
+
+    my $index = index( $self->{buffer}, $self->delimiter_begin );
+
+    if ( $index < 0 ) {
+
+        # make sure we have enough buffer to detect end delimiter
+        my $length = length( $self->{buffer} ) - ( length( $self->delimiter_end ) + 2 );
+
+        unless ( $length > 0 ) {
+            return 0;
+        }
+
+        $self->{part}->{data} .= substr( $self->{buffer}, 0, $length, '' );
+        $self->{part}->{size} += $length;
+        $self->{part}->{done} = 0;
+
+        $self->handler( $self->{part} );
+
+        return 0;
+    }
+
+    $self->{part}->{data} .= substr( $self->{buffer}, 0, $index, '' );
+    $self->{part}->{size} += $index;
+    $self->{part}->{done} = 1;
+
+    $self->handler( $self->{part} );
+
+    $self->{state} = 'boundary';
+
+    return 1;
+}
+
+=item handler
+
+=cut
+
+our $basename_regexp = qr/[^.]+(\.[^\\\/]+)$/;
+#our $basename_regexp = qr/(\.\w+(?:\.\w+)*)$/;
+
+sub handler {
+    my ( $self, $part ) = @_;
+
+    unless ( exists $part->{name} ) {
+
+        my $disposition = $part->{headers}->{'Content-Disposition'};
+        my ($name)      = $disposition =~ / name="?([^\";]+)"?/;
+        my ($filename)  = $disposition =~ / filename="?([^\"]*)"?/;
+        # Need to match empty filenames above, so this part is flagged as an upload type
+
+        $part->{name} = $name;
+
+        if ( defined $filename ) {
+            $part->{filename} = $filename;
+
+            if ( $filename ne "" ) {
+                my $basename = (File::Spec->splitpath($filename))[2];
+                my $suffix = $basename =~ $basename_regexp ? $1 : q{};
+
+                my $fh = File::Temp->new( UNLINK => 0, DIR => $self->tmpdir, SUFFIX => $suffix );
+
+                $part->{fh}       = $fh;
+                $part->{tempname} = $fh->filename;
+            }
+        }
+    }
+
+    if ( $part->{fh} && ( my $length = length( $part->{data} ) ) ) {
+        $part->{fh}->write( substr( $part->{data}, 0, $length, '' ), $length );
+    }
+
+    if ( $part->{done} ) {
+
+        if ( exists $part->{filename} ) {
+            if ( $part->{filename} ne "" ) {
+                $part->{fh}->close if defined $part->{fh};
+
+                delete @{$part}{qw[ data done fh ]};
+
+                $self->upload( $part->{name}, $part );
+            }
+        }
+        # If we have more than the content-disposition, we need to create a
+        # data key so that we don't waste the headers.
+        else {
+            $self->param( $part->{name}, $part->{data} );
+            $self->part_data( $part->{name}, $part )
+        }
+    }
+}
+
+=back
+
+=head1 AUTHOR
+
+Christian Hansen, C<ch@ngmedia.com>
+
+=head1 LICENSE
+
+This library is free software . You can redistribute it and/or modify 
+it under the same terms as perl itself.
+
+=cut
+
+1;

--- a/lib/Dancer/HTTP/Body/OctetStream.pm
+++ b/lib/Dancer/HTTP/Body/OctetStream.pm
@@ -1,0 +1,59 @@
+package Dancer::HTTP::Body::OctetStream;
+
+use strict;
+use base 'Dancer::HTTP::Body';
+use bytes;
+
+use File::Temp 0.14;
+
+=head1 NAME
+
+Dancer::HTTP::Body::OctetStream - HTTP Body OctetStream Parser
+
+=head1 SYNOPSIS
+
+    use Dancer::HTTP::Body::OctetStream;
+
+=head1 DESCRIPTION
+
+HTTP Body OctetStream Parser.
+
+=head1 METHODS
+
+=over 4
+
+=item spin
+
+=cut
+
+sub spin {
+    my $self = shift;
+
+    unless ( $self->body ) {
+        $self->body( File::Temp->new( DIR => $self->tmpdir ) );
+    }
+
+    if ( my $length = length( $self->{buffer} ) ) {
+        $self->body->write( substr( $self->{buffer}, 0, $length, '' ), $length );
+    }
+
+    if ( $self->length == $self->content_length ) {
+        seek( $self->body, 0, 0 );
+        $self->state('done');
+    }
+}
+
+=back
+
+=head1 AUTHOR
+
+Christian Hansen, C<ch@ngmedia.com>
+
+=head1 LICENSE
+
+This library is free software . You can redistribute it and/or modify 
+it under the same terms as perl itself.
+
+=cut
+
+1;

--- a/lib/Dancer/HTTP/Body/UrlEncoded.pm
+++ b/lib/Dancer/HTTP/Body/UrlEncoded.pm
@@ -1,0 +1,94 @@
+package Dancer::HTTP::Body::UrlEncoded;
+
+use strict;
+use base 'Dancer::HTTP::Body';
+use bytes;
+
+our $DECODE = qr/%([0-9a-fA-F]{2})/;
+
+our %hex_chr;
+
+for my $num ( 0 .. 255 ) {
+    my $h = sprintf "%02X", $num;
+    $hex_chr{ lc $h } = $hex_chr{ uc $h } = chr $num;
+}
+
+=head1 NAME
+
+Dancer::HTTP::Body::UrlEncoded - HTTP Body UrlEncoded Parser
+
+=head1 SYNOPSIS
+
+    use Dancer::HTTP::Body::UrlEncoded;
+
+=head1 DESCRIPTION
+
+HTTP Body UrlEncoded Parser.
+
+=head1 METHODS
+
+=over 4
+
+=item spin
+
+=cut
+
+sub spin {
+    my $self = shift;
+
+    # Still Copy buffer to body temp file, just like other parsers - some users
+    # will expect to be able to get at the raw body with the body method still 
+    # (not unreasonably) 
+    unless ($self->body) {
+        $self->body(File::Temp->new(DIR => $self->tmpdir));
+    }
+
+    if (my $length = length($self->{buffer})) {
+        $self->body->write(substr($self->{buffer}, 0, $length, ''),
+            $length);
+    }
+
+    return unless $self->length == $self->content_length;
+    
+    # I tested parsing this using APR::Request, but perl is faster
+    # Pure-Perl    2560/s
+    # APR::Request 2305/s
+    
+    # Note: s/// appears faster than tr///
+
+
+    $self->{buffer} =~ s/\+/ /g;
+
+    for my $pair ( split( /[&;](?:\s+)?/, $self->{buffer} ) ) {
+
+        my ( $name, $value ) = split( /=/, $pair , 2 );
+
+        next unless defined $name;
+        next unless defined $value;
+        
+        $name  =~ s/$DECODE/$hex_chr{$1}/gs;
+        $value =~ s/$DECODE/$hex_chr{$1}/gs;
+
+        $self->param( $name, $value );
+    }
+
+    $self->{buffer} = '';
+    $self->{state}  = 'done';
+}
+
+=back
+
+=head1 AUTHORS
+
+Christian Hansen, C<ch@ngmedia.com>
+
+Andy Grundman, C<andy@hybridized.org>
+
+=head1 LICENSE
+
+This library is free software . You can redistribute it and/or modify 
+it under the same terms as perl itself.
+
+=cut
+
+1;

--- a/lib/Dancer/HTTP/Body/UrlEncoded.pm
+++ b/lib/Dancer/HTTP/Body/UrlEncoded.pm
@@ -44,7 +44,7 @@ sub spin {
     }
 
     if (my $length = length($self->{buffer})) {
-        $self->body->write(substr($self->{buffer}, 0, $length, ''),
+        $self->body->write(substr($self->{buffer}, 0, $length),
             $length);
     }
 

--- a/lib/Dancer/HTTP/Body/XForms.pm
+++ b/lib/Dancer/HTTP/Body/XForms.pm
@@ -1,0 +1,61 @@
+package Dancer::HTTP::Body::XForms;
+
+use strict;
+use base 'Dancer::HTTP::Body';
+use bytes;
+
+use File::Temp 0.14;
+
+=head1 NAME
+
+Dancer::HTTP::Body::XForms - HTTP Body XForms Parser
+
+=head1 SYNOPSIS
+
+    use Dancer::HTTP::Body::XForms;
+
+=head1 DESCRIPTION
+
+HTTP Body XForms Parser. This module parses single part XForms
+submissions, which are identifiable by the content-type
+application/xml. The XML is stored unparsed on the parameter
+XForms:Model.
+
+=head1 METHODS
+
+=over 4
+
+=item spin
+
+This method is overwrited to set the param XForms:Model with
+the buffer content.
+
+=cut
+
+sub spin {
+    my $self = shift;
+
+    return unless $self->length == $self->content_length;
+
+    $self->body($self->{buffer});
+    $self->param( 'XForms:Model', $self->{buffer} );
+    $self->{buffer} = '';
+    $self->{state}  = 'done';
+
+    return $self->SUPER::init();
+}
+
+=back
+
+=head1 AUTHOR
+
+Daniel Ruoso, C<daniel@ruoso.com>
+
+=head1 LICENSE
+
+This library is free software . You can redistribute it and/or modify 
+it under the same terms as perl itself.
+
+=cut
+
+1;

--- a/lib/Dancer/HTTP/Body/XFormsMultipart.pm
+++ b/lib/Dancer/HTTP/Body/XFormsMultipart.pm
@@ -1,0 +1,102 @@
+package Dancer::HTTP::Body::XFormsMultipart;
+
+use strict;
+use base 'Dancer::HTTP::Body::MultiPart';
+use bytes;
+
+use IO::File;
+use File::Temp 0.14;
+
+=head1 NAME
+
+Dancer::HTTP::Body::XFormsMultipart - HTTP Body XForms multipart/related submission Parser
+
+=head1 SYNOPSIS
+
+    use Dancer::HTTP::Body::XForms;
+
+=head1 DESCRIPTION
+
+HTTP Body XForms submission Parser. Inherits Dancer::HTTP::Body::MultiPart.
+
+This body type is used to parse XForms submission. In this case, the
+XML part that contains the model is indicated by the start attribute
+in the content-type. The XML content is stored unparsed on the
+parameter XForms:Model.
+
+=head1 METHODS
+
+=over 4
+
+=item init
+
+This function is overridden to detect the start part of the
+multipart/related post.
+
+=cut
+
+sub init {
+    my $self = shift;
+    $self->SUPER::init(@_);
+    unless ( $self->content_type =~ /start=\"?\<?([^\"\>;,]+)\>?\"?/ ) {
+        my $content_type = $self->content_type;
+        Carp::croak( "Invalid boundary in content_type: '$content_type'" );
+    }
+    
+    $self->{start} = $1;
+
+    return $self;
+}
+
+=item start
+
+Defines the start part of the multipart/related body.
+
+=cut
+
+sub start {
+    return shift->{start};
+}
+
+=item handler
+
+This function is overridden to differ the start part, which should be
+set as the XForms:Model param if its content type is application/xml.
+
+=cut
+
+sub handler {
+    my ( $self, $part ) = @_;
+
+    my $contentid = $part->{headers}{'Content-ID'};
+    $contentid =~ s/^.*[\<\"]//;
+    $contentid =~ s/[\>\"].*$//;
+    
+    if ( $contentid eq $self->start ) {
+        $part->{name} = 'XForms:Model';
+        if ($part->{done}) {
+            $self->body($part->{data});
+        }
+    }
+    elsif ( defined $contentid ) {
+        $part->{name}     = $contentid;
+        $part->{filename} = $contentid;
+    }
+
+    return $self->SUPER::handler($part);
+}
+
+=back
+
+=head1 AUTHOR
+
+Daniel Ruoso C<daniel@ruoso.com>
+
+=head1 LICENSE
+
+This library is free software . You can redistribute it and/or modify 
+it under the same terms as perl itself.
+
+=cut
+
+1;

--- a/lib/Dancer/Request.pm
+++ b/lib/Dancer/Request.pm
@@ -8,12 +8,12 @@ use Carp;
 use base 'Dancer::Object';
 
 use Dancer::Config 'setting';
+use Dancer::HTTP::Body;
 use Dancer::Request::Upload;
 use Dancer::SharedData;
 use Dancer::Session;
 use Dancer::Exception qw(:all);
 use Encode;
-use HTTP::Body;
 use URI;
 use URI::Escape;
 
@@ -140,7 +140,7 @@ sub init {
     $self->_build_method()    unless $self->method;
 
     $self->{_http_body} =
-      HTTP::Body->new($self->content_type, $self->content_length);
+      Dancer::HTTP::Body->new($self->content_type, $self->content_length);
     $self->{_http_body}->cleanup(1);
     $self->_build_params();
     $self->_build_uploads unless $self->uploads;

--- a/t/02_request/20_body.t
+++ b/t/02_request/20_body.t
@@ -1,0 +1,47 @@
+# See Issue 1140
+use Test::More import => ['!pass'];
+use strict;
+use warnings;
+use Dancer::ModuleLoader;
+use Dancer;
+use File::Spec;
+use lib File::Spec->catdir( 't', 'lib' );
+
+plan skip_all => "skip test with Test::TCP in win32/cygwin" if ($^O eq 'MSWin32'or $^O eq 'cygwin');
+plan skip_all => "Test::TCP is needed for this test"
+    unless Dancer::ModuleLoader->load("Test::TCP" => "1.30");
+
+use LWP::UserAgent;
+
+use constant RAW_DATA => "foo=bar&bar=baz";
+
+plan tests => 2;
+my $host = '127.0.0.10';
+Test::TCP::test_tcp(
+    client => sub {
+        my $port = shift;
+        my $rawdata = RAW_DATA;
+        my $ua = LWP::UserAgent->new;
+        my $req = HTTP::Request->new(POST => "http://$host:$port/jsondata");
+        my $headers = { 'Content-Length' => length($rawdata), 'Content-Type' => 'application/x-www-form-urlencoded' };
+        $req->push_header($_, $headers->{$_}) foreach keys %$headers;
+        $req->content($rawdata);
+        my $res = $ua->request($req);
+
+        ok $res->is_success, 'req is success';
+        is $res->content, $rawdata, "raw_data is OK";
+    },
+    server => sub {
+        my $port = shift;
+
+        use TestApp;
+        Dancer::Config->load;
+
+        set( environment  => 'production',
+             port         => $port,
+             server       => $host,
+             startup_info => 0);
+        Dancer->dance();
+    },
+    host => $host,
+);


### PR DESCRIPTION
PR for review & discussion and Travis tests.

This is for Issue #1140.

I proposed a patch to HTTP::Body in https://rt.cpan.org/Ticket/Display.html?id=111876 which makes the UrlEncoded body parser work like the other parsers, storing the raw request body in a filehandle accessible from the body method.  However, I'm not sure it will be accepted, it seems that HTTP::Body isn't particularly actively maintained these days (I know for instance that Plack has moved away from it), so I'm considering shipping a modified version of HTTP::Body with Dancer to get round this.  Ripping out our use of HTTP::Body and replacing it with another parser sounds like too much work for D1, although a valid plan for D2 :)
