### PR TITLE
Validate session IDs

### DIFF
--- a/lib/Dancer/Session/Abstract.pm
+++ b/lib/Dancer/Session/Abstract.pm
@@ -103,7 +103,7 @@ sub read_session_id {
 
     my $name = $class->session_name();
     my $c    = Dancer::Cookies->cookies->{$name};
-    return (defined $c) ? $c->value : undef;
+    return (defined $c && $c->value =~ /^\d+$/) ? $c->value : undef;
 }
 
 sub write_session_id {

--- a/t/08_session/06_abstract.t
+++ b/t/08_session/06_abstract.t
@@ -3,7 +3,7 @@ use Dancer ':syntax';
 
 use Dancer::Session::Abstract;
 
-plan tests => 8;
+plan tests => 10;
 
 eval {
     Dancer::Session::Abstract->retrieve
@@ -39,3 +39,16 @@ is $s->session_name, 'dancer.session', "default name is dancer.session";
 setting session_name => "foo_session";
 $s = Dancer::Session::Abstract->new;
 is $s->session_name, 'foo_session', 'setting session_name is used';
+
+Dancer::Cookies->cookies->{$s->session_name} = Dancer::Cookie->new(
+    name => $s->session_name,
+    value => '../../../../../../../etc/passwd',
+);
+is ($s->read_session_id, undef, "Invalid session ID ignored");
+
+Dancer::Cookies->cookies->{$s->session_name} = Dancer::Cookie->new(
+    name => $s->session_name,
+    value => '123456789',
+);
+is( $s->read_session_id, '123456789', "Valid-looking session ID accepted" );
+


### PR DESCRIPTION
Make sure that a session ID from a session cookie looks valid before trying to use it.  See Issue #1118.