### PR TITLE
Implement support for use of YAML::XS

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -22,6 +22,7 @@ authority=cpan:SUKRIA
 
 [Prereqs / RuntimeRecommends ]
 YAML = 0
+YAML::XS = 0
 
 ; We don't require JSON for runtime, but several serialiser tests should have
 ; it in order to fully test their behaviour - so add it here as a test

--- a/lib/Dancer/Config.pm
+++ b/lib/Dancer/Config.pm
@@ -196,7 +196,7 @@ sub load {
         unless $result;
 
     unless ($_LOADED{conffile()}) {
-        load_settings_from_yaml(conffile);
+        load_settings_from_yaml(conffile, $module);
         $_LOADED{conffile()}++;
     }
 
@@ -205,7 +205,7 @@ sub load {
     # don't load the same env twice
     unless( $_LOADED{$env} ) {
         if (-f $env ) {
-            load_settings_from_yaml($env);
+            load_settings_from_yaml($env, $module);
             $_LOADED{$env}++;
         }
         elsif (setting('require_environment')) {
@@ -225,10 +225,14 @@ sub load {
 }
 
 sub load_settings_from_yaml {
-    my ($file) = @_;
+    my ($file, $module) = @_;
 
-    my $config = eval { YAML::LoadFile($file) }
+    my $config;
+    {
+        no strict 'refs';
+        $config = eval { &{ $module . '::LoadFile' }($file) }
         or confess "Unable to parse the configuration file: $file: $@";
+    }
 
     $SETTINGS = Hash::Merge::Simple::merge( $SETTINGS, {
         map {

--- a/lib/Dancer/Renderer.pm
+++ b/lib/Dancer/Renderer.pm
@@ -60,7 +60,7 @@ sub response_with_headers {
 
     if (Dancer::Config::setting('server_tokens')) {
         $response->{headers} ||= HTTP::Headers->new;
-        my $powered_by = "Perl Dancer " . Dancer->VERSION;
+        my $powered_by = "Perl Dancer " . ( Dancer->VERSION || '' );
         $response->header('X-Powered-By' => $powered_by);
         $response->header('Server'       => $powered_by);
     }

--- a/lib/Dancer/Serializer/YAML.pm
+++ b/lib/Dancer/Serializer/YAML.pm
@@ -28,7 +28,7 @@ sub to_yaml {
 sub loaded { 
     my $module = Dancer::Config::settings->{engines}{YAML}{module} || 'YAML';
 
-    raise core_serializer => q{Dancer::Serializer::YAML only support 'YAML' or 'YAML::XS', not $module}
+    raise core_serializer => q{Dancer::Serializer::YAML only supports 'YAML' or 'YAML::XS', not $module}
         unless $module =~ /^YAML(?:::XS)?$/;
 
     Dancer::ModuleLoader->load($module) 
@@ -42,12 +42,20 @@ sub init {
 
 sub serialize {
     my ($self, $entity) = @_;
-    YAML::Dump($entity);
+    my $module = Dancer::Config::settings->{engines}{YAML}{module} || 'YAML';
+    {
+        no strict 'refs';
+        &{ $module . '::Dump' }($entity);
+    }
 }
 
 sub deserialize {
     my ($self, $content) = @_;
-    YAML::Load($content);
+    my $module = Dancer::Config::settings->{engines}{YAML}{module} || 'YAML';
+    {
+        no strict 'refs';
+        &{ $module . '::Load' }($content);
+    }
 }
 
 sub content_type {'text/x-yaml'}

--- a/t/01_config/04_config_file.t
+++ b/t/01_config/04_config_file.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Test::More import => ['!pass'];
 
-plan skip_all => "YAML needed to run these tests"
+plan skip_all => "YAML or YAML::XS needed to run these tests"
     unless Dancer::ModuleLoader->load('YAML::XS')
         or Dancer::ModuleLoader->load('YAML');
 plan skip_all => "File::Temp 0.22 required"

--- a/t/01_config/04_config_file.t
+++ b/t/01_config/04_config_file.t
@@ -2,8 +2,9 @@ use strict;
 use warnings;
 use Test::More import => ['!pass'];
 
-plan skip_all => "YAML needed to run this tests"
-    unless Dancer::ModuleLoader->load('YAML');
+plan skip_all => "YAML needed to run these tests"
+    unless Dancer::ModuleLoader->load('YAML::XS')
+        or Dancer::ModuleLoader->load('YAML');
 plan skip_all => "File::Temp 0.22 required"
     unless Dancer::ModuleLoader->load( 'File::Temp', '0.22' );
 plan tests => 17;
@@ -20,6 +21,9 @@ mkdir $envdir;
 
 my $conffile = Dancer::Config->conffile;
 ok(defined($conffile), 'default conffile is defined');
+
+Dancer::ModuleLoader->load('YAML::XS')
+    and config->{engines}->{YAML}->{module} = 'YAML::XS';
 
 ok(Dancer::Config->load, 'Config load works without conffile');
 

--- a/t/01_config/06_config_api.t
+++ b/t/01_config/06_config_api.t
@@ -2,18 +2,22 @@ use strict;
 use warnings;
 use Test::More import => ['!pass'];
 
+use Dancer ':syntax';
 use Dancer::Config;
 
-plan skip_all => "YAML needed to run this tests"
-    unless Dancer::ModuleLoader->load('YAML');
+plan skip_all => "YAML needed to run these tests"
+    unless Dancer::ModuleLoader->load('YAML::XS')
+        or Dancer::ModuleLoader->load('YAML');
 
 plan skip_all => "File::Temp 0.22 required"
     unless Dancer::ModuleLoader->load( 'File::Temp', '0.22' );
 
 plan tests => 2;
 
+my $module = Dancer::ModuleLoader->load('YAML::XS') ? 'YAML::XS' : 'YAML';
+
 eval {
-    Dancer::Config::load_settings_from_yaml('foo');
+    Dancer::Config::load_settings_from_yaml('foo', $module);
 };
 
 like $@, qr/Unable to parse the configuration file/, 'non-existent yaml file';
@@ -23,11 +27,11 @@ my $dir = File::Temp::tempdir(CLEANUP => 1, TMPDIR => 1);
 my $config_file = File::Spec->catfile($dir, 'settings.yml');
 
 open my $fh, '>', $config_file;
-print $fh '---"foo';
+print $fh 'foo: bar: baz';
 close $fh;
 
 eval {
-    Dancer::Config::load_settings_from_yaml($config_file);
+    Dancer::Config::load_settings_from_yaml($config_file, $module);
 };
 
 like $@, qr/Unable to parse the configuration file/, 'invalid yaml file';

--- a/t/01_config/06_config_api.t
+++ b/t/01_config/06_config_api.t
@@ -5,7 +5,7 @@ use Test::More import => ['!pass'];
 use Dancer ':syntax';
 use Dancer::Config;
 
-plan skip_all => "YAML needed to run these tests"
+plan skip_all => "YAML or YAML::XS needed to run these tests"
     unless Dancer::ModuleLoader->load('YAML::XS')
         or Dancer::ModuleLoader->load('YAML');
 

--- a/t/01_config/07_strict_config.t
+++ b/t/01_config/07_strict_config.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Test::More import => ['!pass'];
 
-plan skip_all => "YAML needed to run these tests"
+plan skip_all => "YAML or YAML::XS needed to run these tests"
     unless Dancer::ModuleLoader->load('YAML::XS')
         or Dancer::ModuleLoader->load('YAML');
 plan skip_all => "File::Temp 0.22 required"

--- a/t/01_config/07_strict_config.t
+++ b/t/01_config/07_strict_config.t
@@ -2,8 +2,9 @@ use strict;
 use warnings;
 use Test::More import => ['!pass'];
 
-plan skip_all => "YAML needed to run this tests"
-    unless Dancer::ModuleLoader->load('YAML');
+plan skip_all => "YAML needed to run these tests"
+    unless Dancer::ModuleLoader->load('YAML::XS')
+        or Dancer::ModuleLoader->load('YAML');
 plan skip_all => "File::Temp 0.22 required"
     unless Dancer::ModuleLoader->load( 'File::Temp', '0.22' );
 plan tests => 12;
@@ -19,6 +20,9 @@ my $envdir = File::Spec->catdir($dir, 'environments');
 mkdir $envdir;
 
 my $conffile = Dancer::Config->conffile;
+
+Dancer::ModuleLoader->load('YAML::XS')
+    and config->{engines}->{YAML}->{module} = 'YAML::XS';
 
 # create the conffile
 my $conf = <<"END";

--- a/t/01_config/08_environments.t
+++ b/t/01_config/08_environments.t
@@ -3,7 +3,7 @@ use warnings;
 use Test::More import => ['!pass'];
 use Dancer::ModuleLoader;
 
-plan skip_all => "YAML needed to run these tests"
+plan skip_all => "YAML or YAML::XS needed to run these tests"
     unless Dancer::ModuleLoader->load('YAML::XS')
         or Dancer::ModuleLoader->load('YAML');
 

--- a/t/01_config/08_environments.t
+++ b/t/01_config/08_environments.t
@@ -3,8 +3,9 @@ use warnings;
 use Test::More import => ['!pass'];
 use Dancer::ModuleLoader;
 
-Dancer::ModuleLoader->load('YAML')
-    or plan skip_all => 'YAML is needed to run this test';
+plan skip_all => "YAML needed to run these tests"
+    unless Dancer::ModuleLoader->load('YAML::XS')
+        or Dancer::ModuleLoader->load('YAML');
 
 plan tests => 7;
 
@@ -28,6 +29,9 @@ logger: file
 log: "debug"
 ';
 write_file($conffile => $conf);
+
+Dancer::ModuleLoader->load('YAML::XS')
+    and config->{engines}->{YAML}->{module} = 'YAML::XS';
 
 ok(Dancer::Config->load, 'Config load works without conffile');
 

--- a/t/14_serializer/03_request_yaml.t
+++ b/t/14_serializer/03_request_yaml.t
@@ -7,10 +7,14 @@ use Dancer::Test;
 plan tests => 10;
 
 SKIP: {
-    skip 'YAML is needed to run this test', 10
-      unless Dancer::ModuleLoader->load('YAML');
-
-    set serializer => 'YAML', show_errors => 1;
+    if ( Dancer::ModuleLoader->load('YAML::XS') ) {
+        config->{engines}->{YAML}->{module} = 'YAML::XS';
+        set serializer => 'YAML', show_errors => 1;
+    }  elsif ( Dancer::ModuleLoader->load('YAML') ) {
+        set serializer => 'YAML', show_errors => 1;
+    } else {
+        skip 'YAML::XS or YAML is needed to run this test', 10;
+    }
 
     get '/'          => sub { { foo => 'bar' } };
     post '/'         => sub { request->params };

--- a/t/14_serializer/05_request_mutable.t
+++ b/t/14_serializer/05_request_mutable.t
@@ -6,12 +6,16 @@ use Dancer::Test;
 
 BEGIN {
     plan skip_all => 'YAML is needed to run this test'
-      unless Dancer::ModuleLoader->load('YAML');
+      unless Dancer::ModuleLoader->load('YAML::XS')
+        or Dancer::ModuleLoader->load('YAML');
     plan skip_all => 'JSON is needed to run this test'
       unless Dancer::ModuleLoader->load('JSON');
 }
 
 plan tests => 10;
+
+Dancer::ModuleLoader->load('YAML::XS')
+    and config->{engines}->{YAML}->{module} = 'YAML::XS';
 
 setting serializer => 'mutable';
 

--- a/t/14_serializer/05_request_mutable.t
+++ b/t/14_serializer/05_request_mutable.t
@@ -5,7 +5,7 @@ use Dancer ':tests';
 use Dancer::Test;
 
 BEGIN {
-    plan skip_all => 'YAML is needed to run this test'
+    plan skip_all => 'YAML or YAML::XS is needed to run this test'
       unless Dancer::ModuleLoader->load('YAML::XS')
         or Dancer::ModuleLoader->load('YAML');
     plan skip_all => 'JSON is needed to run this test'

--- a/t/15_plugins/02_config.t
+++ b/t/15_plugins/02_config.t
@@ -4,7 +4,8 @@ use Dancer::ModuleLoader;
 use Test::More import => ['!pass'];
 
 plan skip_all => "YAML is needed for this test"
-    unless Dancer::ModuleLoader->load('YAML');
+    unless Dancer::ModuleLoader->load('YAML::XS')
+        or Dancer::ModuleLoader->load('YAML');
 
 plan skip_all => "File::Temp 0.22 required"
     unless Dancer::ModuleLoader->load( 'File::Temp', '0.22' );
@@ -38,6 +39,9 @@ plugins:
   Test:
     foo: baz
 CONF
+
+Dancer::ModuleLoader->load('YAML::XS')
+    and config->{engines}->{YAML}->{module} = 'YAML::XS';
 
 ok( Dancer::Config->load, 'Config load works with a conffile' );
 

--- a/t/15_plugins/02_config.t
+++ b/t/15_plugins/02_config.t
@@ -3,7 +3,7 @@ use warnings;
 use Dancer::ModuleLoader;
 use Test::More import => ['!pass'];
 
-plan skip_all => "YAML is needed for this test"
+plan skip_all => "YAML or YAML::XS is needed for this test"
     unless Dancer::ModuleLoader->load('YAML::XS')
         or Dancer::ModuleLoader->load('YAML');
 


### PR DESCRIPTION
 This PR completes implementation of support for use of YAML::XS for serialization and reading config, as already begun and documented in [PR 1072](https://github.com/PerlDancer/Dancer/pull/1072), but not currently working.

Support for using YAML::XS for sessions has not been implemented.
