### PR TITLE
perfer X-Forwarded-Proto to prevent users lying

### DIFF
--- a/lib/Dancer/Request.pm
+++ b/lib/Dancer/Request.pm
@@ -76,9 +76,9 @@ sub scheme                {
         # PSGI specs say that X_FORWARDED_PROTO will
         # be converted into HTTP_X_FORWARDED_PROTO
         # but Dancer::Test doesn't use PSGI (for now)
-        $scheme = $_[0]->env->{'X_FORWARDED_PROTOCOL'}
+        $scheme = $_[0]->env->{'HTTP_X_FORWARDED_PROTO'}
+               || $_[0]->env->{'X_FORWARDED_PROTOCOL'}
                || $_[0]->env->{'HTTP_X_FORWARDED_PROTOCOL'}
-               || $_[0]->env->{'HTTP_X_FORWARDED_PROTO'}
                || $_[0]->env->{'HTTP_FORWARDED_PROTO'}
                || $_[0]->env->{'X_FORWARDED_PROTO'}
                || ""


### PR DESCRIPTION
X-Forwarded-Proto should be the preferred header to used to check if the
front end connection was HTTPS. Proto is the de facto standard for
this, and is recommended in the deployment documentation.

If the -Protocol header is checked first, that means most setups that
only add a -Proto header will pass through a user provided -Protocol
header, allowing users to lie about the protocol used.

Ideally this would only check one header, and the reverse proxy would be
required to send that header. Leaving this with the fallback behavior
for now for backwards compatibility.