### PR TITLE
Session ID validation

### DIFF
--- a/lib/Dancer/Session/Abstract.pm
+++ b/lib/Dancer/Session/Abstract.pm
@@ -120,6 +120,14 @@ sub read_session_id {
 # session ID, but the actual sesssion contents)
 sub validate_session_id {
     my ($class, $id) = @_;
+
+    # FIXME: it's dirty for the superclass to know about subclasses, but the
+    # alternative is breakage for anyone using D::S::Cookie who updates Dancer
+    # but not D::::Cookie at the same time, so for now, skip session ID
+    # validation for D::S::Cookie (because the cookie doesn't actually contain
+    # just a session ID, but rather the whole serialised & signed session)
+    return 1 if $class->isa('Dancer::Session::Cookie');
+
     return $id =~ m{^[A-Za-z0-9_\-~]+$};
 }
 

--- a/lib/Dancer/Session/Abstract.pm
+++ b/lib/Dancer/Session/Abstract.pm
@@ -115,9 +115,8 @@ sub read_session_id {
 # Validate session ID (base64 chars plus hyphen by default) to avoid potential
 # issues, e.g. if the ID is used insecurely elsewhere.  If a session provider
 # expects more unusual IDs, it can override this class method with one that
-# validates according to that provider's expectation (probably necessary for
-# D::S::Cookie, for instance, where the value of the session cookie isn't the
-# session ID, but the actual sesssion contents)
+# validates according to that provider's expectation of how a session ID should
+# look.
 sub validate_session_id {
     my ($class, $id) = @_;
     return $id =~ m{^[A-Za-z0-9_\-~]+$};

--- a/lib/Dancer/Session/Abstract.pm
+++ b/lib/Dancer/Session/Abstract.pm
@@ -103,7 +103,24 @@ sub read_session_id {
 
     my $name = $class->session_name();
     my $c    = Dancer::Cookies->cookies->{$name};
-    return (defined $c) ? $c->value : undef;
+    return unless defined $c;
+    if ($class->validate_session_id($c->value)) {
+        return $c->value;
+    } else {
+        warn "Rejecting invalid session ID ". $c->value;
+        return;
+    }
+}
+
+# Validate session ID (base64 chars plus hyphen by default) to avoid potential
+# issues, e.g. if the ID is used insecurely elsewhere.  If a session provider
+# expects more unusual IDs, it can override this class method with one that
+# validates according to that provider's expectation (probably necessary for
+# D::S::Cookie, for instance, where the value of the session cookie isn't the
+# session ID, but the actual sesssion contents)
+sub validate_session_id {
+    my ($class, $id) = @_;
+    return $id =~ m{^[A-Za-z0-9_\-~]+$};
 }
 
 sub write_session_id {
@@ -264,7 +281,7 @@ Build a new uniq id.
 
 =item B<read_session_id>
 
-Reads the C<dancer.session> cookie.
+Reads the session ID from the cookie, ensuring it's syntactically valid.
 
 =item B<write_session_id>
 

--- a/lib/Dancer/Session/Abstract.pm
+++ b/lib/Dancer/Session/Abstract.pm
@@ -120,14 +120,6 @@ sub read_session_id {
 # session ID, but the actual sesssion contents)
 sub validate_session_id {
     my ($class, $id) = @_;
-
-    # FIXME: it's dirty for the superclass to know about subclasses, but the
-    # alternative is breakage for anyone using D::S::Cookie who updates Dancer
-    # but not D::::Cookie at the same time, so for now, skip session ID
-    # validation for D::S::Cookie (because the cookie doesn't actually contain
-    # just a session ID, but rather the whole serialised & signed session)
-    return 1 if $class->isa('Dancer::Session::Cookie');
-
     return $id =~ m{^[A-Za-z0-9_\-~]+$};
 }
 


### PR DESCRIPTION
Ensure the session ID read from the session cookie looks reasonable, in case it's something that we wouln't want to pass on to a session storage backend to retrieve, etc.