### PR TITLE
Use __FILE__ instead of $0 and don't print in tests

### DIFF
--- a/t/00_base/09_load_app.t
+++ b/t/00_base/09_load_app.t
@@ -3,13 +3,8 @@ use strict;
 use warnings;
 
 use Dancer ':syntax';
-my $dir = '';
-BEGIN {
-	use File::Basename;
-	$dir = dirname($0) . "/lib";
-	print "\nDIR: [" . $dir . "]\n\n";
-}
-use lib $dir;
+use File::Basename;
+use lib dirname(__FILE__) . "/lib";
 
 # XXX appdir is set to the path of the current test
 use Dancer::Test appdir => path($0);


### PR DESCRIPTION
`__FILE__` is more reliable to find the path to this test file. Also inlined it into the use lib statement so BEGIN isn't needed. Removed the errant print statement which can screw up TAP.