### PR TITLE
Use dzil plugin bundle Dancer, not YANICK

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -17,6 +17,7 @@ filename = Changes
 -bundle=@Dancer
 -remove=Covenant
 -remove=Test::UnusedVars
+-remove=Test::NoTabs
 -remove=ChangeStats::Git
 -remove=Manifest
 NextVersion::Semantic.format=%d.%02d%02d

--- a/dist.ini
+++ b/dist.ini
@@ -18,7 +18,6 @@ filename = Changes
 -remove=Covenant
 -remove=Test::UnusedVars
 -remove=ChangeStats::Git
--remove=AutoPrereqs
 -remove=Manifest
 NextVersion::Semantic.format=%d.%02d%02d
 autoprereqs_skip=Person|mro
@@ -42,7 +41,6 @@ JSON = 2.90
 HTTP::Tiny = 0.014 ; for get/post/post_form
 HTTP::CookieJar = 0.008
 
-[Prereqs::FromCPANfile]
 
 [MetaNoIndex]
 ; Don't let PAUSE index the shipped version of HTTP::Body

--- a/dist.ini
+++ b/dist.ini
@@ -6,7 +6,7 @@ copyright_year   = 2010
 main_module = lib/Dancer.pm
 
 [@Filter]
--bundle=@YANICK
+-bundle=@Dancer
 -remove=Covenant
 -remove=Test::UnusedVars
 -remove=ChangeStats::Git

--- a/dist.ini
+++ b/dist.ini
@@ -5,11 +5,21 @@ copyright_holder = Alexis Sukrieh
 copyright_year   = 2010
 main_module = lib/Dancer.pm
 
+version = 1.3203
+
+[NextRelease]
+filename = Changes
+
+[TestRelease]
+[ConfirmRelease]
+
 [@Filter]
 -bundle=@Dancer
 -remove=Covenant
 -remove=Test::UnusedVars
 -remove=ChangeStats::Git
+-remove=AutoPrereqs
+-remove=Manifest
 NextVersion::Semantic.format=%d.%02d%02d
 autoprereqs_skip=Person|mro
 ChangeStats::Git.develop_branch=devel
@@ -32,8 +42,11 @@ JSON = 2.90
 HTTP::Tiny = 0.014 ; for get/post/post_form
 HTTP::CookieJar = 0.008
 
+[Prereqs::FromCPANfile]
+
 [MetaNoIndex]
 ; Don't let PAUSE index the shipped version of HTTP::Body
 directory = lib/Dancer/HTTP
+
 
 ; authordep Dist::Zilla::Plugin::Test::ReportPrereqs


### PR DESCRIPTION
Let's see if this fixes some of the build failures on certain Perl versions.

e.g.: https://travis-ci.org/PerlDancer/Dancer/builds/356132511

```
-> FAIL Installing the dependencies failed: Module 'Dist::Zilla::Plugin::Covenant' is not installed
-> FAIL Bailing out the installation for Dist-Zilla-PluginBundle-YANICK-0.28.0.
```

(see full build log: https://api.travis-ci.org/v3/job/356132516/log.txt )

We should probably be using the Dancer plugin bundle anyway.