### PR TITLE
Route matching problems if %+ already populated (issue 1187)

### DIFF
--- a/lib/Dancer/Route.pm
+++ b/lib/Dancer/Route.pm
@@ -87,9 +87,13 @@ sub match {
 
     my @values = $path =~ $self->{_compiled_regexp};
 
-    Dancer::Logger::core("  --> got ".
-        map { defined $_ ? $_ : 'undef' } @values)
-        if @values;
+    return unless @values;
+
+    Dancer::Logger::core(
+        "  --> got " .
+        map { defined $_ ? $_ : 'undef' } @values
+    );
+
 
     # if some named captures found, return captures
     # no warnings is for perl < 5.10
@@ -103,7 +107,6 @@ sub match {
         return $self->save_match_data($request, {captures => \%captures});
     }
 
-    return unless @values;
 
     # save the route pattern that matched
     # TODO : as soon as we have proper Dancer::Internal, we should remove


### PR DESCRIPTION
This is for Issue #1187.

It's not safe to look at `%+` without first having checked whether the regex
matched successfully or not.  Otherwise, we might see keys from a previous regex
match, because `%+` is only cleared after a successful match.

(perldoc perlvar confirms, "Note: "%-" and "%+" are tied views into a common
internal hash associated with the last successful regular expression.")

Dancer2 doesn't have problems here, as it already returns immediately if the
regex didn't match, the same way this change does.

Note: I think this would only happen via certain deployment methods, and if
there was an earlier route which used named captures.

In particular, we never had any problems in our large API app's comprehensive
test suite when we used Dancer::Test.  We've re-worked our testing framework to
use Plack::Test, partially in readyness to switch to Dancer2, and started
getting weird failures which were tracked down to incorrect route matching, and
this was the cause.