### PR TITLE
YAML test failures (issue 1184)

### DIFF
--- a/t/01_config/06_config_api.t
+++ b/t/01_config/06_config_api.t
@@ -34,7 +34,7 @@ for my $module (qw(YAML::XS YAML)) {
         my $config_file = File::Spec->catfile($dir, 'settings.yml');
 
         open my $fh, '>', $config_file;
-        print $fh 'foo: bar: baz';
+        print $fh '><(((o>'; # fishy-looking YAML
         close $fh;
 
         eval {

--- a/t/01_config/06_config_api.t
+++ b/t/01_config/06_config_api.t
@@ -12,28 +12,42 @@ plan skip_all => "YAML or YAML::XS needed to run these tests"
 plan skip_all => "File::Temp 0.22 required"
     unless Dancer::ModuleLoader->load( 'File::Temp', '0.22' );
 
-plan tests => 2;
 
-my $module = Dancer::ModuleLoader->load('YAML::XS') ? 'YAML::XS' : 'YAML';
+for my $module (qw(YAML::XS YAML)) {
+    SKIP: {
+        if (!Dancer::ModuleLoader->load($module)) {
+            skip "$module not available", 2;
+        }
 
-eval {
-    Dancer::Config::load_settings_from_yaml('foo', $module);
-};
+        my $mversion = $module->VERSION;
+        diag "Testing YAML parsing with $module version $mversion";
 
-like $@, qr/Unable to parse the configuration file/, 'non-existent yaml file';
+        eval {
+            Dancer::Config::load_settings_from_yaml('foo', $module);
+        };
 
-my $dir = File::Temp::tempdir(CLEANUP => 1, TMPDIR => 1);
+        like $@, qr/Unable to parse the configuration file/,
+            "non-existent YAML file reported correctly, using $module";
 
-my $config_file = File::Spec->catfile($dir, 'settings.yml');
+        my $dir = File::Temp::tempdir(CLEANUP => 1, TMPDIR => 1);
 
-open my $fh, '>', $config_file;
-print $fh 'foo: bar: baz';
-close $fh;
+        my $config_file = File::Spec->catfile($dir, 'settings.yml');
 
-eval {
-    Dancer::Config::load_settings_from_yaml($config_file, $module);
-};
+        open my $fh, '>', $config_file;
+        print $fh 'foo: bar: baz';
+        close $fh;
 
-like $@, qr/Unable to parse the configuration file/, 'invalid yaml file';
+        eval {
+            Dancer::Config::load_settings_from_yaml($config_file, $module);
+        };
 
-File::Temp::cleanup();
+        like $@, qr/Unable to parse the configuration file/,
+            "invalid YAML file reported correctly, using $module";
+
+        File::Temp::cleanup();
+    }
+
+}
+
+done_testing();
+


### PR DESCRIPTION
`t/01_config/06_config_api.t` fails sometimes.  Turns out it fails if you don't have YAML::XS installed, and that's because YAML::XS correctly baulks at invalid YAML, `'foo: bar: baz'`, but YAML.pm is happy to accept that.

So,

- overhaul these tests to test using both YAML and YAML::XS, and make it clear which one we're testing so failures are clearer
- use more-invalid invalid YAML in the test. 