### PR TITLE
Restore old load_settings_from_yaml() calling convention.

### DIFF
--- a/lib/Dancer/Config.pm
+++ b/lib/Dancer/Config.pm
@@ -189,11 +189,7 @@ sub load {
     return 1 unless -f conffile;
 
     # load YAML
-    my $module = $SETTINGS->{engines}{YAML}{module} || 'YAML';
-
-    my ( $result, $error ) = Dancer::ModuleLoader->load($module);
-    confess "Configuration file found but could not load $module: $error"
-        unless $result;
+    my $module = load_yaml_module();
 
     unless ($_LOADED{conffile()}) {
         load_settings_from_yaml(conffile, $module);
@@ -227,6 +223,8 @@ sub load {
 sub load_settings_from_yaml {
     my ($file, $module) = @_;
 
+    $module ||= load_yaml_module();
+
     my $config;
     {
         no strict 'refs';
@@ -241,6 +239,18 @@ sub load_settings_from_yaml {
     } );
 
     return scalar keys %$config;
+}
+
+sub load_yaml_module {
+    my ($module) = @_;
+
+    $module ||= $SETTINGS->{engines}{YAML}{module} || 'YAML';
+
+    my ( $result, $error ) = Dancer::ModuleLoader->load($module);
+    confess "Could not load $module: $error"
+        unless $result;
+
+    return $module;
 }
 
 sub load_default_settings {


### PR DESCRIPTION
Since c6b870cb2, this call requires an additional $module parameter.
This patch makes that argument optional and falls back to the old
behavior if missing.

And the reason for doing this is to (still) be able to overlay multiple
config files without having to either hardcode the YAML preference
or ferret out the current setting beforehand in userland.