### PR TITLE
A couple of spelling fixes in POD

### DIFF
--- a/lib/Dancer/Cookbook.pod
+++ b/lib/Dancer/Cookbook.pod
@@ -889,7 +889,7 @@ even in your environment configuration files:
     plack_middlewares:
       -
         - Debug          # first element of the array is the name of the middleware
-        - panels         # following elements are the configuration ofthe middleware
+        - panels         # following elements are the configuration of the middleware
         -
             - DBITrace
             - Memory

--- a/lib/Dancer/Development.pod
+++ b/lib/Dancer/Development.pod
@@ -290,7 +290,7 @@ However, you can run tests directly using the 'prove' tool:
     $ prove -lv t/some_test_file.t
     $ prove -lvr t/
 
-In most cases, 'prove' is entirely sufficent for you to test any
+In most cases, 'prove' is entirely sufficient for you to test any
 patches you have.
 
 You may need to satisfy some dependencies. The easiest way to satisfy

--- a/lib/Dancer/Plugin/Ajax.pm
+++ b/lib/Dancer/Plugin/Ajax.pm
@@ -87,7 +87,7 @@ The route handler code will be compiled to behave like the following:
 
 =item *
 
-Pass if the request header X-Requested-With doesnt equal XMLHttpRequest
+Pass if the request header X-Requested-With doesn't equal XMLHttpRequest
 
 =item *
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to Dancer.
We thought you might be interested in it too.

    Description: A couple of spelling fixes in POD
     Nothing overly important, but still good to have fixed
    Author: Damyan Ivanov <dmn@debian.org>

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libdancer-perl/raw/master/debian/patches/pod-spelling.patch

Thanks for considering,
  Damyan Ivanov,
  Debian Perl Group
