### PR TITLE
Error.pm - more censorship in the dumps

### DIFF
--- a/lib/Dancer/Error.pm
+++ b/lib/Dancer/Error.pm
@@ -165,7 +165,7 @@ sub _censor {
         if (ref $hash->{$key} eq 'HASH') {
             $censored += _censor( $hash->{$key}, $recursecount );
         }
-        elsif ($key =~ /(pass|card?num|pan|cvv|cvv2|ccv|secret|private_key)/i) {
+        elsif ($key =~ /(pass|card?num|pan|cvv2?|ccv|secret|private_key|cookie_key)/i) {
             $hash->{$key} = "Hidden (looks potentially sensitive)";
             $censored++;
         }


### PR DESCRIPTION
D::S::Cookie relies on a secret key for security, don't dump it.

Fixes: Dancer#1192
