### PR TITLE
Use FindBin to work around the lack of '.' in @INC.

### DIFF
--- a/t/00_base/12_utf8_charset.t
+++ b/t/00_base/12_utf8_charset.t
@@ -7,6 +7,9 @@ use Test::More import => ['!pass'];
 use Dancer::ModuleLoader;
 use HTTP::Tiny;
 
+use FindBin qw($Bin);
+use lib "$Bin/../../";
+
 plan skip_all => "skip test with Test::TCP in win32/cygwin" if ($^O eq 'MSWin32' or $^O eq 'cygwin');
 plan skip_all => "Test::TCP is needed for this test"
     unless Dancer::ModuleLoader->load("Test::TCP" => '1.30');

--- a/t/06_helpers/06_load.t
+++ b/t/06_helpers/06_load.t
@@ -3,6 +3,9 @@ use Test::More 'no_plan', import => ['!pass'];
 use Dancer ':syntax';
 use Dancer::Test;
 
+use FindBin qw($Bin);
+use lib "$Bin/../../";
+
 my $routes = path('t', '06_helpers', 'routes.pl');
 
 ok( -f $routes, "file routes is found");

--- a/t/11_logger/02_factory.t
+++ b/t/11_logger/02_factory.t
@@ -2,6 +2,10 @@ use Test::More import => ['!pass'];
 
 use strict;
 use warnings;
+
+use FindBin qw($Bin);
+use lib "$Bin/../../";
+
 use t::lib::TestUtils;
 
 use Dancer ':syntax';

--- a/t/11_logger/03_file.t
+++ b/t/11_logger/03_file.t
@@ -3,6 +3,9 @@ use Test::More import => ['!pass'];
 use strict;
 use warnings;
 
+use FindBin qw($Bin);
+use lib "$Bin/../../";
+
 use t::lib::TestUtils;
 use Dancer;
 

--- a/t/15_plugins/06_hook.t
+++ b/t/15_plugins/06_hook.t
@@ -5,6 +5,8 @@ use Dancer ':syntax';
 use Dancer::Test;
 
 use lib 't/lib';
+use FindBin qw($Bin);
+use lib "$Bin/../../";
 
 plan tests => 6;
 


### PR DESCRIPTION
Tests had started failing on modern (>=5.26?) perls which don't have '.'
in @INC.

Fixes #1194.