### PR TITLE
Fix various cpantesters failures especially proxy-related

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Dancer
 
 {{$NEXT}}
 
+1.3401    2018-10-01 12:49:53+01:00 Europe/London (TRIAL RELEASE)
+
  [ENHANCEMENTS]
  - Avoid test failures on perls without '.' in @INC
  - censor cookie_key in dumps (PR-1193, thefatphil) 

--- a/MANIFEST
+++ b/MANIFEST
@@ -96,6 +96,7 @@ lib/Dancer/Template/TemplateToolkit.pm
 lib/Dancer/Test.pm
 lib/Dancer/Timer.pm
 lib/Dancer/Tutorial.pod
+lib/HTTP/Tiny/NoProxy.pm
 t/00-compile.t
 t/00-report-prereqs.dd
 t/00-report-prereqs.t

--- a/lib/Dancer/Config.pm
+++ b/lib/Dancer/Config.pm
@@ -227,6 +227,8 @@ sub load {
 sub load_settings_from_yaml {
     my ($file, $module) = @_;
 
+    $module ||= 'YAML';
+
     my $config;
     {
         no strict 'refs';

--- a/lib/Dancer/Serializer/YAML.pm
+++ b/lib/Dancer/Serializer/YAML.pm
@@ -42,6 +42,7 @@ sub init {
 
 sub serialize {
     my ($self, $entity) = @_;
+    return unless $entity;
     my $module = Dancer::Config::settings->{engines}{YAML}{module} || 'YAML';
     {
         no strict 'refs';
@@ -52,6 +53,7 @@ sub serialize {
 sub deserialize {
     my ($self, $content) = @_;
     my $module = Dancer::Config::settings->{engines}{YAML}{module} || 'YAML';
+    return unless $content;
     {
         no strict 'refs';
         &{ $module . '::Load' }($content);

--- a/lib/Dancer/Session/YAML.pm
+++ b/lib/Dancer/Session/YAML.pm
@@ -85,6 +85,7 @@ sub yaml_file {
     # Untaint Session ID before using it in file actions
     # required when running under Perl Taint mode
     $id =~ m/^([\d]*)$/;
+    return unless $1;
     my $yaml_file = "$1.yml";
 
     return path(setting('session_dir'), $yaml_file);

--- a/lib/HTTP/Tiny/NoProxy.pm
+++ b/lib/HTTP/Tiny/NoProxy.pm
@@ -1,0 +1,22 @@
+package HTTP::Tiny::NoProxy;
+
+use base 'HTTP::Tiny';
+
+# Simple subclass of HTTP::Tiny, adding the no_proxy argument, because we're
+# talking to 127.0.0.1 and it makes no sense to use a proxy for that - and
+# causes lots of cpantesters failures on any boxes that have proxy env vars set.
+#
+# See https://github.com/chansen/p5-http-tiny/pull/118 for a PR I raised for
+# HTTP::Tiny to automatically ignore proxy settings for 127.0.0.1/localhost.
+
+
+sub new {
+    my ($self, %args) = @_;
+
+    $args{no_proxy} = "127.0.0.1";
+
+    return $self->SUPER::new(%args);
+}
+
+
+1;

--- a/t/00_base/12_utf8_charset.t
+++ b/t/00_base/12_utf8_charset.t
@@ -5,7 +5,7 @@ use utf8;
 use Encode;
 use Test::More import => ['!pass'];
 use Dancer::ModuleLoader;
-use HTTP::Tiny;
+use HTTP::Tiny::NoProxy;
 
 use FindBin qw($Bin);
 use lib "$Bin/../../";
@@ -63,7 +63,7 @@ sub d {
 sub _get_http_response {
     my ($method, $path, $port) = @_;
 
-    my $ua = HTTP::Tiny->new;
+    my $ua = HTTP::Tiny::NoProxy->new;
     return $ua->request($method => "http://127.0.0.1:$port${path}");
 }
 

--- a/t/02_request/07_raw_data.t
+++ b/t/02_request/07_raw_data.t
@@ -10,7 +10,7 @@ plan skip_all => "skip test with Test::TCP in win32/cygwin" if ($^O eq 'MSWin32'
 plan skip_all => "Test::TCP is needed for this test"
     unless Dancer::ModuleLoader->load("Test::TCP" => "1.30");
 
-use HTTP::Tiny;
+use HTTP::Tiny::NoProxy;
 
 use constant RAW_DATA => "var: 2; foo: 42; bar: 57\nHey I'm here.\r\n\r\n";
 
@@ -21,7 +21,7 @@ Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
         my $rawdata = RAW_DATA;
-        my $ua = HTTP::Tiny->new;
+        my $ua = HTTP::Tiny::NoProxy->new;
         my $headers = { 'Content-Length' => length($rawdata) };
         my $res = $ua->put("http://$host:$port/jsondata", { headers => $headers, content => $rawdata });
 

--- a/t/02_request/10_mixed_params.t
+++ b/t/02_request/10_mixed_params.t
@@ -11,13 +11,13 @@ plan skip_all => "skip test with Test::TCP in win32" if ($^O eq 'MSWin32' or $^O
 plan skip_all => "Test::TCP is needed for this test"
     unless Dancer::ModuleLoader->load("Test::TCP" => "1.30");
 
-use HTTP::Tiny;
+use HTTP::Tiny::NoProxy;
 
 plan tests => 2;
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
-        my $ua = HTTP::Tiny->new;
+        my $ua = HTTP::Tiny::NoProxy->new;
         my $res = $ua->post_form("http://127.0.0.1:$port/params/route?a=1&var=query",
                             {var => 'post', b => 2});
 

--- a/t/02_request/13_ajax.t
+++ b/t/02_request/13_ajax.t
@@ -7,13 +7,13 @@ plan skip_all => 'Test::TCP is needed to run this test'
     unless Dancer::ModuleLoader->load('Test::TCP' => "1.30");
 plan tests => 8;
 
-use HTTP::Tiny;
+use HTTP::Tiny::NoProxy;
 use HTTP::Headers;
 
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
-        my $ua = HTTP::Tiny->new;
+        my $ua = HTTP::Tiny::NoProxy->new;
 
         my $headers = { 'X-Requested-With' => 'XMLHttpRequest' };
         my $res = $ua->get("http://127.0.0.1:$port/req", { headers => $headers });

--- a/t/02_request/15_headers.t
+++ b/t/02_request/15_headers.t
@@ -6,7 +6,7 @@ plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
 plan skip_all => 'Test::TCP is needed to run this test'
     unless Dancer::ModuleLoader->load('Test::TCP' => "1.30");
 
-use HTTP::Tiny;
+use HTTP::Tiny::NoProxy;
 
 my $plack_available = Dancer::ModuleLoader->load('Plack::Request');
 Dancer::ModuleLoader->load('Plack::Loader') if $plack_available;
@@ -20,7 +20,7 @@ for my $handler (@handlers) {
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
-        my $ua = HTTP::Tiny->new;
+        my $ua = HTTP::Tiny::NoProxy->new;
 
         my $headers = { 'X-User-Head1' => 42, 'X-User-Head2' => 43 };
 

--- a/t/02_request/20_body.t
+++ b/t/02_request/20_body.t
@@ -12,7 +12,7 @@ plan skip_all => "skip test with Test::TCP in win32/cygwin" if ($^O eq 'MSWin32'
 plan skip_all => "Test::TCP is needed for this test"
     unless Dancer::ModuleLoader->load("Test::TCP" => "1.30");
 
-use HTTP::Tiny;
+use HTTP::Tiny::NoProxy;
 
 use constant RAW_DATA => "foo=bar&bar=baz";
 
@@ -23,7 +23,7 @@ Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
         my $rawdata = RAW_DATA;
-        my $ua = HTTP::Tiny->new;
+        my $ua = HTTP::Tiny::NoProxy->new;
         my $headers = { 'Content-Length' => length($rawdata), 'Content-Type' => 'application/x-www-form-urlencoded' };
         my $res = $ua->request(POST => "http://$host:$port/jsondata", { headers => $headers, content => $rawdata });
 

--- a/t/03_route_handler/21_ajax.t
+++ b/t/03_route_handler/21_ajax.t
@@ -8,7 +8,7 @@ plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
 plan skip_all => 'Test::TCP is needed to run this test'
     unless Dancer::ModuleLoader->load('Test::TCP' => "1.30");
 
-use HTTP::Tiny;
+use HTTP::Tiny::NoProxy;
 
 plan tests => 33;
 
@@ -21,7 +21,7 @@ ok(!Dancer::App->current->registry->is_empty,
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
-        my $ua = HTTP::Tiny->new;
+        my $ua = HTTP::Tiny::NoProxy->new;
 
         my @queries = (
             { path => 'req', ajax => 1, success => 1, content => 1 },

--- a/t/03_route_handler/28_plack_mount.t
+++ b/t/03_route_handler/28_plack_mount.t
@@ -11,7 +11,7 @@ BEGIN {
       unless Dancer::ModuleLoader->load('Plack::Builder');
 }
 
-use HTTP::Tiny;
+use HTTP::Tiny::NoProxy;
 
 use Plack::Builder; # should be loaded in BEGIN block, but it seems that it's not the case ...
 use HTTP::Server::Simple::PSGI;
@@ -23,7 +23,7 @@ Test::TCP::test_tcp(
         my $port = shift;
         my $url = "http://127.0.0.1:$port/mount/test/foo";
 
-        my $ua = HTTP::Tiny->new();
+        my $ua = HTTP::Tiny::NoProxy->new();
         ok my $res = $ua->get($url);
         ok $res->{success};
         is $res->{content}, '/foo';

--- a/t/03_route_handler/33_vars.t
+++ b/t/03_route_handler/33_vars.t
@@ -5,7 +5,7 @@ use warnings;
 
 use Test::More;
 
-use HTTP::Tiny;
+use HTTP::Tiny::NoProxy;
 
 plan skip_all => "skip test with Test::TCP in win32" if $^O eq 'MSWin32';
 plan skip_all => "Test::TCP is needed for this test"
@@ -15,7 +15,7 @@ plan tests => 10;
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
-        my $ua  = HTTP::Tiny->new;
+        my $ua  = HTTP::Tiny::NoProxy->new;
         for (1..10) {
             my $res = $ua->get("http://127.0.0.1:$port/getvarfoo");
             is $res->{content}, 1;

--- a/t/03_route_handler/34_forward_body_post.t
+++ b/t/03_route_handler/34_forward_body_post.t
@@ -15,7 +15,7 @@ BEGIN {
 }
 
 use Dancer;
-use HTTP::Tiny;
+use HTTP::Tiny::NoProxy;
 
 plan tests => 2;
 
@@ -23,7 +23,7 @@ Test::TCP::test_tcp(
   client => sub {
       my $port = shift;
       my $url_base  = "http://127.0.0.1:$port";
-      my $ua  = HTTP::Tiny->new;
+      my $ua  = HTTP::Tiny::NoProxy->new;
       my $res = $ua->post_form($url_base . "/foo", { data => 'foo'});
       is($res->{content}, "data:foo");
 

--- a/t/04_static_file/001_base.t
+++ b/t/04_static_file/001_base.t
@@ -43,12 +43,12 @@ my $r = Dancer::SharedData->response();
 is $r->status,  400;
 is $r->content, 'Bad Request';
 
-require HTTP::Tiny;
+require HTTP::Tiny::NoProxy;
 
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
-        my $ua  = HTTP::Tiny->new();
+        my $ua  = HTTP::Tiny::NoProxy->new();
         my $res = $ua->get("http://127.0.0.1:$port/hello%00.txt");
         ok !$res->{success};
         is $res->{status}, 400;
@@ -67,7 +67,7 @@ Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
         my $headers = { 'If-Modified-Since' => $date };
-        my $ua  = HTTP::Tiny->new();
+        my $ua  = HTTP::Tiny::NoProxy->new();
         my $res = $ua->get("http://127.0.0.1:$port/hello.txt", { headers => $headers });
         ok !$res->{success};
         is $res->{status}, 304;

--- a/t/07_apphandlers/03_psgi_app.t
+++ b/t/07_apphandlers/03_psgi_app.t
@@ -9,7 +9,7 @@ plan skip_all => "Test::TCP is needed to run this test"
 plan skip_all => "Plack is needed to run this test"
     unless Dancer::ModuleLoader->load('Plack::Request');
 
-use HTTP::Tiny;
+use HTTP::Tiny::NoProxy;
 
 Dancer::ModuleLoader->load('Plack::Loader');
 
@@ -20,7 +20,7 @@ plan tests => 3;
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
-        my $ua = HTTP::Tiny->new;
+        my $ua = HTTP::Tiny::NoProxy->new;
 
         my $res = $ua->get("http://127.0.0.1:$port/env");
         like $res->{content}, qr/psgi\.version/,

--- a/t/07_apphandlers/04_standalone_app.t
+++ b/t/07_apphandlers/04_standalone_app.t
@@ -9,14 +9,14 @@ plan skip_all => "Test::TCP is needed for this test"
 plan skip_all => "Test::TCP is needed for this test"
     unless Dancer::ModuleLoader->load("Plack::Loader");
 
-use HTTP::Tiny;
+use HTTP::Tiny::NoProxy;
 
 plan tests => 6;
 
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
-        my $ua = HTTP::Tiny->new;
+        my $ua = HTTP::Tiny::NoProxy->new;
 
         my $res = $ua->get("http://127.0.0.1:$port/env");
         like $res->{content}, qr/PATH_INFO/, 'path info is found in response';

--- a/t/07_apphandlers/05_middlewares.t
+++ b/t/07_apphandlers/05_middlewares.t
@@ -4,7 +4,7 @@ use warnings;
 
 use Dancer ':syntax';
 use Dancer::ModuleLoader;
-use HTTP::Tiny;
+use HTTP::Tiny::NoProxy;
 
 use File::Spec;
 use lib File::Spec->catdir( 't', 'lib' );
@@ -26,7 +26,7 @@ foreach my $c (@$confs) {
     Test::TCP::test_tcp(
         client => sub {
             my $port = shift;
-            my $ua   = HTTP::Tiny->new;
+            my $ua   = HTTP::Tiny::NoProxy->new;
 
             my $res = $ua->get("http://127.0.0.1:$port/");
             ok $res;

--- a/t/07_apphandlers/07_middleware_map.t
+++ b/t/07_apphandlers/07_middleware_map.t
@@ -4,7 +4,7 @@ use warnings;
 
 use Dancer ':syntax';
 use Dancer::ModuleLoader;
-use HTTP::Tiny;
+use HTTP::Tiny::NoProxy;
 
 use File::Spec;
 use lib File::Spec->catdir('t','lib');
@@ -27,7 +27,7 @@ plan tests => (2 * scalar @tests);
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
-        my $ua   = HTTP::Tiny->new;
+        my $ua   = HTTP::Tiny::NoProxy->new;
 
         foreach my $test (@tests) {
             my $res = $ua->get("http://127.0.0.1:$port" . $test->{path});

--- a/t/08_session/03_http_requests.t
+++ b/t/08_session/03_http_requests.t
@@ -15,7 +15,7 @@ BEGIN {
         unless Dancer::ModuleLoader->load( 'File::Temp', '0.22' );
 }
 
-use HTTP::Tiny;
+use HTTP::Tiny::NoProxy;
 use HTTP::CookieJar;
 
 use File::Spec;
@@ -42,7 +42,7 @@ Test::TCP::test_tcp(
         my $port = shift;
 
         foreach my $client (@clients) {
-            my $ua = HTTP::Tiny->new(cookie_jar => HTTP::CookieJar->new);
+            my $ua = HTTP::Tiny::NoProxy->new(cookie_jar => HTTP::CookieJar->new);
 
             my $res = $ua->get("http://127.0.0.1:$port/read_session");
             like $res->{content}, qr/name=''/, 

--- a/t/08_session/05_yaml.t
+++ b/t/08_session/05_yaml.t
@@ -38,7 +38,7 @@ is_deeply $s, $session, "session is retrieved";
 is_deeply( Dancer::Session::YAML->retrieve( $session->id ),
     $session->retrieve( $session->id ) );
 
-my $yaml_file = $session->yaml_file;
+my $yaml_file = Dancer::Session::YAML::yaml_file($session->id);
 like $yaml_file, qr/\.yml$/, 'session file have valid name';
 
 $session->{foo} = 42;

--- a/t/08_session/07_session_expires.t
+++ b/t/08_session/07_session_expires.t
@@ -21,7 +21,7 @@ plan skip_all => "YAML is needed for this test"
 
 plan tests => 8;
 
-use HTTP::Tiny;
+use HTTP::Tiny::NoProxy;
 use File::Path 'rmtree';
 use Dancer::Config;
 
@@ -40,7 +40,7 @@ for my $session_expires (keys %tests) {
     Test::TCP::test_tcp(
         client => sub {
             my $port = shift;
-            my $ua   = HTTP::Tiny->new;
+            my $ua   = HTTP::Tiny::NoProxy->new;
             my $res = $ua->get("http://127.0.0.1:$port/set_session/test");
             ok $res->{success}, 'req is success';
             my $cookie = $res->{headers}{'set-cookie'};

--- a/t/08_session/13_session_httponly.t
+++ b/t/08_session/13_session_httponly.t
@@ -14,7 +14,7 @@ plan skip_all => "YAML is needed for this test"
 
 plan tests => 3 * 3;
 
-use HTTP::Tiny;
+use HTTP::Tiny::NoProxy;
 use File::Path 'rmtree';
 use Dancer::Config;
 
@@ -25,7 +25,7 @@ for my $setting ("default", "on", "off") {
     Test::TCP::test_tcp(
         client => sub {
             my $port = shift;
-            my $ua   = HTTP::Tiny->new;
+            my $ua   = HTTP::Tiny::NoProxy->new;
             my $res = $ua->get("http://127.0.0.1:$port/set_session/test_13");
             ok $res->{success}, 'req is success';
             my $cookie = $res->{headers}{'set-cookie'};

--- a/t/09_cookies/03_persistence.t
+++ b/t/09_cookies/03_persistence.t
@@ -10,7 +10,7 @@ BEGIN {
         unless Dancer::ModuleLoader->load('Test::TCP' => "1.30");
 };
 
-use HTTP::Tiny;
+use HTTP::Tiny::NoProxy;
 use HTTP::CookieJar;
 use Dancer;
 
@@ -22,7 +22,7 @@ Test::TCP::test_tcp(
         my $port = shift;
 
         foreach my $client (qw(one two three)) {
-            my $ua = HTTP::Tiny->new(cookie_jar => HTTP::CookieJar->new);
+            my $ua = HTTP::Tiny::NoProxy->new(cookie_jar => HTTP::CookieJar->new);
 
             my $res = $ua->get("http://127.0.0.1:$port/cookies");
             like $res->{content}, qr/\$VAR1 = \{\}/,

--- a/t/12_response/04_charset_server.t
+++ b/t/12_response/04_charset_server.t
@@ -15,14 +15,14 @@ plan skip_all => "Test::TCP is needed for this test"
 plan skip_all => "HTTP::Headers $min_hh required (use of content_type_charset)"
     unless Dancer::ModuleLoader->load( 'HTTP::Headers', $min_hh );
 
-use HTTP::Tiny;
+use HTTP::Tiny::NoProxy;
 
 plan tests => 10;
 
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
-        my $ua = HTTP::Tiny->new;
+        my $ua = HTTP::Tiny::NoProxy->new;
         my $res = $ua->post_form("http://127.0.0.1:$port/name", [ name => 'vasya' ]);
 
         my $headers = HTTP::Headers->new(%{$res->{headers}});
@@ -56,7 +56,7 @@ Test::TCP::test_tcp(
 Test::TCP::test_tcp(
     client => sub {
         my $port = shift;
-        my $ua = HTTP::Tiny->new;
+        my $ua = HTTP::Tiny::NoProxy->new;
 
         my $res = $ua->get("http://127.0.0.1:$port/unicode-content-length");
 
@@ -92,7 +92,7 @@ SKIP: {
     Test::TCP::test_tcp(
         client => sub {
             my $port = shift;
-            my $ua = HTTP::Tiny->new;
+            my $ua = HTTP::Tiny::NoProxy->new;
 
             my $res = $ua->get("http://127.0.0.1:$port/unicode-content-length-json");
 

--- a/t/12_response/08_drop_content.t
+++ b/t/12_response/08_drop_content.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use Test::More import => ['!pass'];
-use HTTP::Tiny;
+use HTTP::Tiny::NoProxy;
 
 BEGIN {
     use Dancer::ModuleLoader;
@@ -23,7 +23,7 @@ sub test {
             my $port = shift;
             my $url  = "http://127.0.0.1:$port/";
 
-            my $ua = HTTP::Tiny->new;
+            my $ua = HTTP::Tiny::NoProxy->new;
             for (qw/204 304/) {
                 my $res = $ua->get($url . $_);
                 ok !$res->{content}, 'no content for '.$_;

--- a/t/14_serializer/17_clear_serializer.t
+++ b/t/14_serializer/17_clear_serializer.t
@@ -2,7 +2,7 @@ use Dancer ':tests';
 use Dancer::Test;
 use Test::More;
 use Dancer::ModuleLoader;
-use HTTP::Tiny;
+use HTTP::Tiny::NoProxy;
 
 plan skip_all => "skip test with Test::TCP in win32" if  $^O eq 'MSWin32';
 plan skip_all => 'Test::TCP is needed to run this test'
@@ -20,7 +20,7 @@ my $data = { foo => 'bar' };
 Test::TCP::test_tcp(
     client => sub {
         my $port    = shift;
-        my $ua      = HTTP::Tiny->new;
+        my $ua      = HTTP::Tiny::NoProxy->new;
         my $res;
 
         $res = $ua->get("http://127.0.0.1:$port/");

--- a/t/15_plugins/07_ajax_plack_builder.t
+++ b/t/15_plugins/07_ajax_plack_builder.t
@@ -13,7 +13,7 @@ BEGIN {
       unless Dancer::ModuleLoader->load('Plack::Builder');
 }
 
-use HTTP::Tiny;
+use HTTP::Tiny::NoProxy;
 use Plack::Builder;
 use HTTP::Server::Simple::PSGI;
 
@@ -32,7 +32,7 @@ Test::TCP::test_tcp(
         my $port = shift;
         my $url  = "http://127.0.0.1:$port/";
 
-        my $ua  = HTTP::Tiny->new();
+        my $ua  = HTTP::Tiny::NoProxy->new();
 
         ok my $res = $ua->get($url), 'Got GET result';
         ok $res->{success}, 'Successful';

--- a/t/21_dependents/Dancer-Session-Cookie.t
+++ b/t/21_dependents/Dancer-Session-Cookie.t
@@ -23,10 +23,10 @@ test_tcp(
     client => sub {
         my $port = shift;
 
-        require HTTP::Tiny;
+        require HTTP::Tiny::NoProxy;
         require HTTP::CookieJar;
 
-        my $ua = HTTP::Tiny->new;
+        my $ua = HTTP::Tiny::NoProxy->new;
 
         # Simulate two different browsers with two different jars
         my @jars = (HTTP::CookieJar->new, HTTP::CookieJar->new);

--- a/t/24_deployment/01_multi_webapp.t
+++ b/t/24_deployment/01_multi_webapp.t
@@ -13,7 +13,7 @@ BEGIN {
 
 use Dancer;
 use Plack::Builder;
-use HTTP::Tiny;
+use HTTP::Tiny::NoProxy;
 use HTTP::Server::Simple::PSGI;
 
 plan tests => 100;
@@ -23,7 +23,7 @@ Test::TCP::test_tcp(
         my $port = shift;
 
         my @apps = (qw/app1 app2/);
-        my $ua = HTTP::Tiny->new();
+        my $ua = HTTP::Tiny::NoProxy->new();
         for(1..100){
             my $app = $apps[int(rand(scalar @apps - 1))];
             my $res = $ua->get("http://127.0.0.1:$port/$app");


### PR DESCRIPTION
We're getting quite a few cpantesters failures where smokers have HTTP proxy env vars set, and HTTP::Tiny honours them when trying to talk to 127.0.0.1, which obviously isn't going to work so well.

So, replaced all uses of HTTP::Tiny with a new tiny subclass, HTTP::Tiny::NoProxy, which knows to ignore the proxy settings for 127.0.0.1.

Also fixed up some other warnings output by our tests too.