### PR TITLE
request->address should respect behind_proxy.

### DIFF
--- a/lib/Dancer/Config.pm
+++ b/lib/Dancer/Config.pm
@@ -346,6 +346,16 @@ If set to true, Dancer will look to C<X-Forwarded-Protocol> and
 C<X-Forwarded-host> when constructing URLs (for example, when using
 C<redirect>. This is useful if your application is behind a proxy.
 
+It will also cause L<< Dancer::Request->address|Dancer::Request/address >>
+to return what L<< Dancer::Request->forwarded_for_address|Dancer::Request/forwarded_for_address >>
+would return, namely the content of the `HTTP_X_FORWARDED_FOR` env var/header,
+so that requests will appear to have come from the end user's IP and
+not the proxy's.
+
+Because of the above, you should *not* turn this on if your app isn't
+behind a proxy which will pass this information on appropriately, otherwise
+a malicious user could supply false information.
+
 =head2 Content type / character set
 
 =head3 content_type (string)

--- a/lib/Dancer/Request.pm
+++ b/lib/Dancer/Request.pm
@@ -53,7 +53,11 @@ sub new {
 sub agent                 { $_[0]->user_agent }
 sub remote_address        { $_[0]->address }
 sub forwarded_for_address { $_[0]->env->{'X_FORWARDED_FOR'} || $_[0]->env->{'HTTP_X_FORWARDED_FOR'} }
-sub address               { $_[0]->env->{REMOTE_ADDR} }
+sub address {
+    setting('behind_proxy')
+        ? $_[0]->forwarded_for_address()
+        : $_[0]->env->{REMOTE_ADDR}
+}
 sub host {
     if (@_==2) {
         $_[0]->{host} = $_[1];


### PR DESCRIPTION
If behind_proxy is set, then it makes sense for `request->address` to return the
address that `request->forwarded_for_address()` would return.

Otherwise, all code that was written without proxying in mind (and even our
built-in logging, too) will return the IP of the proxy, rather than the client.

TODO: document in the `behind_proxy` doco that it will change the behaviour of
`request->address`.

TODO: decide if this is definitely a good idea.  I think it is - I think it's
somewhat surprising that `request->address` *doesn't* respect `behind_proxy`.