### PR TITLE
Add unmock support

### DIFF
--- a/t/lib/EasyMocker.pm
+++ b/t/lib/EasyMocker.pm
@@ -35,10 +35,6 @@ sub mock {
             $orig_coderef{$method} = \&$method;
             *$method = $sub;
         }
-
-        use Data::Dump;
-        warn "After adding mock, \%orig_coderef: "
-            . Data::Dump::dump(\%orig_coderef);
     }
 }
 


### PR DESCRIPTION
Adds support in EasyMocker (`t/lib/EasyMocker`) for unmocking stuff previously mocked.

I wanted to be able to do this in another test, and it surprised me that I couldn't.

It may be sensible to replace EasyMocker with one of the CPAN well-used ones, but it's simple and it works.