### PR TITLE
Write session cookie once

### DIFF
--- a/lib/Dancer/Response.pm
+++ b/lib/Dancer/Response.pm
@@ -169,6 +169,10 @@ sub add_cookie {
     $self->{_cookies}{$name} = $cookie;
 }
 
+sub get_cookie {
+    my ($self, $name) = @_;
+    return $self->{_cookies}{$name};
+}
 
 # When the response is about to be rendered, that's when we build up the
 # Set-Cookie headers

--- a/lib/Dancer/Response.pm
+++ b/lib/Dancer/Response.pm
@@ -169,10 +169,6 @@ sub add_cookie {
     $self->{_cookies}{$name} = $cookie;
 }
 
-sub get_cookie {
-    my ($self, $name) = @_;
-    return $self->{_cookies}{$name};
-}
 
 # When the response is about to be rendered, that's when we build up the
 # Set-Cookie headers

--- a/lib/Dancer/Session/Abstract.pm
+++ b/lib/Dancer/Session/Abstract.pm
@@ -9,6 +9,7 @@ use base 'Dancer::Engine';
 
 use Dancer::Config 'setting';
 use Dancer::Cookies;
+use Dancer::SharedData;
 use File::Spec;
 
 __PACKAGE__->attributes('id');
@@ -126,6 +127,13 @@ sub write_session_id {
     my ($class, $id) = @_;
 
     my $name = $class->session_name();
+
+    # If we've already pushed the appropriate cookie to the response, then we
+    # don't need to do any more
+    if (Dancer::SharedData->response->get_cookie($name)) {
+        return;
+    }
+
     my %cookie = (
         name   => $name,
         value  => $id,

--- a/lib/Dancer/Session/Abstract.pm
+++ b/lib/Dancer/Session/Abstract.pm
@@ -9,7 +9,6 @@ use base 'Dancer::Engine';
 
 use Dancer::Config 'setting';
 use Dancer::Cookies;
-use Dancer::SharedData;
 use File::Spec;
 
 __PACKAGE__->attributes('id');
@@ -130,7 +129,7 @@ sub write_session_id {
 
     # If we've already pushed the appropriate cookie to the response, then we
     # don't need to do any more
-    if (Dancer::SharedData->response->get_cookie($name)) {
+    if (Dancer::Cookies->cookie($name)) {
         return;
     }
 

--- a/t/08_session/03_http_requests.t
+++ b/t/08_session/03_http_requests.t
@@ -33,7 +33,7 @@ if ($ENV{DANCER_TEST_COOKIE}) {
 }
 
 
-plan tests => 7 * scalar(@clients) * scalar(@engines) + (scalar(@engines));
+plan tests => 9 * scalar(@clients) * scalar(@engines) + (scalar(@engines));
 
 foreach my $engine (@engines) {
 
@@ -69,6 +69,16 @@ Test::TCP::test_tcp(
                 $res->{content},
                 "Read value changed in hook",
                 "Session var set changed in hook successfully",
+            );
+
+            # Now read once more, to make sure that the session var set in the
+            # after hook in the last test was actually persisted:
+            $res = $ua->get("http://127.0.0.1:$port/session/after_hook");
+            ok($res->{success}, "Fetched the session var");
+            is(
+                $res->{content},
+                "value changed in hook",
+                "Session var set in hook persisted",
             );
 
         }

--- a/t/08_session/03_http_requests.t
+++ b/t/08_session/03_http_requests.t
@@ -25,7 +25,7 @@ use Dancer;
 use Dancer::Logger;
  
 my @clients = qw(one two three);
-my @engines = qw(YAML);
+my @engines = qw(Simple YAML);
 
 if ($ENV{DANCER_TEST_COOKIE}) {
     push @engines, "cookie";

--- a/t/08_session/03_http_requests.t
+++ b/t/08_session/03_http_requests.t
@@ -48,7 +48,7 @@ if ($ENV{DANCER_TEST_SESSION_DBI_DSN}) {
 }
 
 
-plan tests => 9 * scalar(@clients) * scalar(@engines) + (scalar(@engines));
+plan tests => 11 * scalar(@clients) * scalar(@engines) + (scalar(@engines));
 
 foreach my $engine (@engines) {
 
@@ -95,6 +95,19 @@ Test::TCP::test_tcp(
                 "value changed in hook",
                 "Session var set in hook persisted",
             );
+
+            $res = $ua->get("http://127.0.0.1:$port/session/after_hook/send_file");
+            ok(
+                $res->{success},
+                "after hook accessing session after send_file doesn't explode"
+                . " (GH #1205)",
+            );
+            is(
+                $res->{content},
+                "Hi there, random person (after hook fired)",
+                "send_file route sent expected content and no explosion",
+            );
+
 
         }
     },

--- a/t/08_session/03_http_requests.t
+++ b/t/08_session/03_http_requests.t
@@ -33,7 +33,7 @@ if ($ENV{DANCER_TEST_COOKIE}) {
 }
 
 
-plan tests => 3 * scalar(@clients) * scalar(@engines) + (scalar(@engines));
+plan tests => 7 * scalar(@clients) * scalar(@engines) + (scalar(@engines));
 
 foreach my $engine (@engines) {
 
@@ -54,6 +54,22 @@ Test::TCP::test_tcp(
             $res = $ua->get("http://127.0.0.1:$port/read_session");
             like $res->{content}, qr/name='$client'/,
             "session looks good for client $client";
+
+            $res = $ua->get("http://127.0.0.1:$port/session/after_hook/read");
+            ok($res->{success}, "Reading a session var in after hook worked");
+            is(
+                $res->{content},
+                "Read value set in route",
+                "Session var read in after hook and returned",
+            );
+
+            $res = $ua->get("http://127.0.0.1:$port/session/after_hook/write");
+            ok($res->{success}, "writing a session var in after hook worked");
+            is(
+                $res->{content},
+                "Read value changed in hook",
+                "Session var set changed in hook successfully",
+            );
 
         }
     },

--- a/t/08_session/03_http_requests.t
+++ b/t/08_session/03_http_requests.t
@@ -32,6 +32,21 @@ if ($ENV{DANCER_TEST_COOKIE}) {
     setting(session_cookie_key => "secret/foo*@!");
 }
 
+# Support testing with Dancer::Session::DBI if explictly told to by being
+# provided with DB connection details via env vars (the appropriate table would
+# have to have been created, too)
+if ($ENV{DANCER_TEST_SESSION_DBI_DSN}) {
+    push @engines, "DBI";
+    setting(
+        session_options => {
+            dsn      => $ENV{DANCER_TEST_SESSION_DBI_DSN},
+            user     => $ENV{DANCER_TEST_SESSION_DBI_USER},
+            password => $ENV{DANCER_TEST_SESSION_DBI_PASS},
+            table    => $ENV{DANCER_TEST_SESSION_DBI_TABLE},
+        }
+    );
+}
+
 
 plan tests => 9 * scalar(@clients) * scalar(@engines) + (scalar(@engines));
 
@@ -94,6 +109,8 @@ Test::TCP::test_tcp(
         setting appdir => $tempdir;
         Dancer::Logger->init('File');
         ok(setting(session => $engine), "using engine $engine");
+        setting(log => "debug");
+        setting(logger => "console");
         set( show_errors  => 1,
              startup_info => 0,
              environment  => 'production',

--- a/t/17_apps/02_load_app.t
+++ b/t/17_apps/02_load_app.t
@@ -29,8 +29,8 @@ ok defined($forum), "app 'Forum' is defined";
 is @{ $main->registry->routes->{'get'} }, 1, 
     "one route is defined in main app";
 
-is @{ $test_app->registry->routes->{'get'} }, 16, 
-    "16 routes are defined in test app";
+is @{ $test_app->registry->routes->{'get'} }, 18, 
+    "18 routes are defined in test app";
 
 is @{ $forum->registry->routes->{'get'} }, 5, 
     "5 routes are defined in forum app";

--- a/t/17_apps/02_load_app.t
+++ b/t/17_apps/02_load_app.t
@@ -20,7 +20,7 @@ is scalar(@$apps), 3, "3 applications exist";
 
 for (
     { name => "main",    routes => 1  },
-    { name => "TestApp", routes => 19 },
+    { name => "TestApp", routes => 20 },
     { name => "Forum",   routes => 5  },
 )
 {

--- a/t/17_apps/02_load_app.t
+++ b/t/17_apps/02_load_app.t
@@ -18,22 +18,23 @@ use lib File::Spec->catdir( 't', 'lib' );
 my $apps = [ Dancer::App->applications ];
 is scalar(@$apps), 3, "3 applications exist";
 
-my $main     = Dancer::App->get('main');
-my $test_app = Dancer::App->get('TestApp');
-my $forum    = Dancer::App->get('Forum');
-
-ok defined($main), "app 'main' is defined";
-ok defined($test_app), "app 'TestApp' is defined";
-ok defined($forum), "app 'Forum' is defined";
-
-is @{ $main->registry->routes->{'get'} }, 1, 
-    "one route is defined in main app";
-
-is @{ $test_app->registry->routes->{'get'} }, 19, 
-    "19 routes are defined in test app";
-
-is @{ $forum->registry->routes->{'get'} }, 5, 
-    "5 routes are defined in forum app";
+for (
+    { name => "main",    routes => 1  },
+    { name => "TestApp", routes => 19 },
+    { name => "Forum",   routes => 5  },
+)
+{
+    my $app = Dancer::App->get($_->{name});
+    ok(
+        defined($app)
+        , "app $_->{name} is defined",
+    );
+    is(
+        @{ $app->registry->routes('get') },
+        $_->{routes},
+        "Expected number of get routes defined for " . $_->{name},
+    );
+}
 
 response_content_is [GET => "/forum/index"], "forum index"; 
 response_content_is [GET => "/forum/admin/index"], "admin index"; 

--- a/t/17_apps/02_load_app.t
+++ b/t/17_apps/02_load_app.t
@@ -29,8 +29,8 @@ ok defined($forum), "app 'Forum' is defined";
 is @{ $main->registry->routes->{'get'} }, 1, 
     "one route is defined in main app";
 
-is @{ $test_app->registry->routes->{'get'} }, 18, 
-    "18 routes are defined in test app";
+is @{ $test_app->registry->routes->{'get'} }, 19, 
+    "19 routes are defined in test app";
 
 is @{ $forum->registry->routes->{'get'} }, 5, 
     "5 routes are defined in forum app";

--- a/t/lib/TestApp.pm
+++ b/t/lib/TestApp.pm
@@ -59,6 +59,33 @@ get '/read_session' => sub {
     "name='$name'"
 };
 
+# For testing whether we can *read* a session var within the after hook (but not
+# set, because it's too late by then
+get '/session/after_hook/read' => sub {
+    session after_hook => "value set in route";
+    return "Meh";
+};
+hook after => sub {
+    my $response = shift;
+    if (request->path eq '/session/after_hook/read') {
+        $response->content("Read " . session('after_hook'));
+    }
+};
+
+# But we can't *set* a session var in the after hook, as the headers have been
+# built
+get '/session/after_hook/write' => sub {
+    session after_hook => "value set in route";
+    return "Meh";
+};
+hook after => sub {
+    my $response = shift;
+    if (request->path eq '/session/after_hook/write') {
+        session after_hook => "value changed in hook";
+        $response->content("Read " . session('after_hook'));
+    }
+};
+
 any['put','post'] => '/jsondata' => sub {
     request->body;
 };

--- a/t/lib/TestApp.pm
+++ b/t/lib/TestApp.pm
@@ -86,6 +86,10 @@ hook after => sub {
     }
 };
 
+get '/session/after_hook' => sub {
+    session('after_hook');
+};
+
 any['put','post'] => '/jsondata' => sub {
     request->body;
 };

--- a/t/lib/TestApp.pm
+++ b/t/lib/TestApp.pm
@@ -106,11 +106,6 @@ hook after => sub {
         );
     }
 };
-hook before_serializer => sub {
-    if (1 || request->path eq '/session/after_hook/write') {
-        my $name = session('person');
-    }
-};
 
 any['put','post'] => '/jsondata' => sub {
     request->body;


### PR DESCRIPTION
Previously, every time we try to read from a session, `write_session_id` would generate a new session cookie to add to the response (overwriting the previously-generated one each time) - this is a bit silly and wasteful, but more importantly, causes `Too late to set another cookie, headers already built` errors if you try to access a session var from e.g. an `after` hook.

So, check if we have already added the appropriate session cookie to the response object, and if so, all is fine, do nothing.

