### PR TITLE
More session tweaks

### DIFF
--- a/lib/Dancer/Session.pm
+++ b/lib/Dancer/Session.pm
@@ -28,7 +28,9 @@ sub get_current_session {
     my $session = undef;
     my $class   = ref(engine);
 
-    if ($session = Dancer::SharedData->session) {
+    my $sessions = Dancer::SharedData->sessions || {};
+    my $name    = $class->session_name();
+    if ($sid and $session = $sessions->{$name}{$sid}) {
         return $session;
     }
     
@@ -38,7 +40,8 @@ sub get_current_session {
         $session = $class->create();
     }
 
-    Dancer::SharedData->session($session);
+    $sessions->{$name}{$session->id} = $session;
+    Dancer::SharedData->sessions($sessions);
 
     # Generate a session cookie; we want to do this regardless of whether the
     # session is new or existing, so that the cookie expiry is updated.

--- a/lib/Dancer/Session.pm
+++ b/lib/Dancer/Session.pm
@@ -28,11 +28,17 @@ sub get_current_session {
     my $session = undef;
     my $class   = ref(engine);
 
+    if ($session = Dancer::SharedData->session) {
+        return $session;
+    }
+    
     $session = $class->retrieve($sid) if $sid;
 
     if (not defined $session) {
         $session = $class->create();
     }
+
+    Dancer::SharedData->session($session);
 
     # Generate a session cookie; we want to do this regardless of whether the
     # session is new or existing, so that the cookie expiry is updated.

--- a/lib/Dancer/Session/Abstract.pm
+++ b/lib/Dancer/Session/Abstract.pm
@@ -131,8 +131,10 @@ sub write_session_id {
 
     # If we've already pushed the appropriate cookie to the response, then we
     # don't need to do any more
-    if (Dancer::Cookies->cookie($name)) {
-        return;
+    if (my $cookie = Dancer::Cookies->cookie($name)) {
+        if ($cookie eq $id) {
+            return;
+        }
     }
 
     my %cookie = (

--- a/lib/Dancer/Session/Abstract.pm
+++ b/lib/Dancer/Session/Abstract.pm
@@ -54,7 +54,9 @@ sub is_lazy { 0 };
 # that the session ID is still generated.
 sub init {
     my ($self) = @_;
-    $self->id(build_id());
+    if (!$self->id) {
+        $self->id(build_id());
+    }
 }
 
 # this method can be overwritten in any Dancer::Session::* module

--- a/lib/Dancer/SharedData.pm
+++ b/lib/Dancer/SharedData.pm
@@ -41,6 +41,10 @@ sub response {
 }
 sub reset_response { $_response = undef }
 
+# session singleton
+my $_session;
+sub session { (@_ == 2) ? $_session = $_[1] : $_session }
+
 # request timer
 my $_timer;
 sub timer { $_timer ||= Dancer::Timer->new }
@@ -56,6 +60,7 @@ sub reset_all {
     if (!$is_forward) {
         $vars = {};
     }
+    undef $_session;
     undef $_request;
     undef $_headers;
     reset_timer();

--- a/lib/Dancer/SharedData.pm
+++ b/lib/Dancer/SharedData.pm
@@ -41,9 +41,9 @@ sub response {
 }
 sub reset_response { $_response = undef }
 
-# session singleton
-my $_session;
-sub session { (@_ == 2) ? $_session = $_[1] : $_session }
+# sessions singleton
+my $_sessions;
+sub sessions { (@_ == 2) ? $_sessions = $_[1] : $_sessions }
 
 # request timer
 my $_timer;
@@ -60,7 +60,7 @@ sub reset_all {
     if (!$is_forward) {
         $vars = {};
     }
-    undef $_session;
+    undef $_sessions;
     undef $_request;
     undef $_headers;
     reset_timer();


### PR DESCRIPTION
Additional tweaks to session handling.

The biggest, most useful one: caching the session contents in  `Dancer::SharedData->session` for the duration of the request.  Before, we would fetch the session contents each time you request something from it, e.g. `session('foo')` - so in some cases (fetching lots of different keys, or a `session()` call within a loop that gets executed lots of times) we could fetch the session contents a whole lot of times - which isn't ideal, particularly if the session engine in use means an expensive DB round trip each time, etc.

Also, a fix to the "only try to set the session cookie once" stuff from PR #1205 - check if we have the cookie already *and the value matches*, in case the session ID has changed during the request.