### PR TITLE
Handle YAML.pm 1.30

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Dancer
 
 {{$NEXT}}
+
+1.3512    2019-03-31 20:10:08+01:00 Europe/London
 Promoting previous trial release 1.3511 to stable.
 
 1.3511    2019-03-29 11:16:08+00:00 Europe/London (TRIAL RELEASE)

--- a/lib/Dancer/Session/YAML.pm
+++ b/lib/Dancer/Session/YAML.pm
@@ -74,7 +74,7 @@ sub retrieve {
     my $content = YAML::LoadFile($fh);
     close $fh or die "Can't close '$session_file': $!\n";
 
-    return $content;
+    return bless $content => $class;
 }
 
 # instance

--- a/lib/Dancer/Session/YAML.pm
+++ b/lib/Dancer/Session/YAML.pm
@@ -74,7 +74,7 @@ sub retrieve {
     my $content = YAML::LoadFile($fh);
     close $fh or die "Can't close '$session_file': $!\n";
 
-    return bless $content => $class;
+    return bless $content => ref($class) || $class;
 }
 
 # instance


### PR DESCRIPTION
Fixes for #1208 - YAML deserialisation failures with YAML.pm >= 1.30.

YAML.pm version 1.30 made a breaking change, setting `$YAML::LoadBlessed` to default to false for security: https://metacpan.org/source/TINITA/YAML-1.30/Changes#L2

When we load a session from a YAML file, it will not be blessed for us any more, so bless it ourselves.