### PR TITLE
Support SameSite cookie attribute.

### DIFF
--- a/lib/Dancer/Session/Abstract.pm
+++ b/lib/Dancer/Session/Abstract.pm
@@ -144,6 +144,8 @@ sub write_session_id {
         secure => setting('session_secure'),
         http_only => defined(setting("session_is_http_only")) ?
                      setting("session_is_http_only") : 1,
+        same_site => defined(setting("session_same_site")) ?
+                    setting("session_same_site") ? 'None',
     );
     if (my $expires = setting('session_expires')) {
         # It's # of seconds from the current time

--- a/t/09_cookies/05_api.t
+++ b/t/09_cookies/05_api.t
@@ -3,9 +3,10 @@ use Dancer ':syntax';
 
 my @tests = (
     { name => 'foo', value => 42 ,            opts => {}},
-    { name => 'foo', value => 42 ,            opts => { http_only => 1 } },
-    { name => 'msg', value => 'hello; world', opts => {} },
-    { name => 'msg', value => 'hello; world', opts => { http_only => 0 } },
+    { name => 'foo', value => 42 ,            opts => { http_only => 1 }     },
+    { name => 'msg', value => 'hello; world', opts => {}                     },
+    { name => 'msg', value => 'hello; world', opts => { http_only => 0 }     },
+    { name => 'ss',  value => 'samesitetest', opts => { same_site => 'Lax' } },
 );
 
 plan tests => scalar (@tests * 5) + 12;
@@ -21,6 +22,9 @@ foreach my $test (@tests) {
     is $c->http_only,
        (exists($test->{opts}{http_only}) ? $test->{opts}{http_only} : undef),
        "HttpOnly is correctly set";
+    is $c->same_site,
+       (exists($test->{opts}{same_site}) ? $test->{opts}{same_site} : undef),
+       "SameSite is correctly set";
 }
 
 {


### PR DESCRIPTION
Needs careful testing.

Also, we probably don't want to set the attribute if the user hasn't asked us to; at present the code will set it to 'None' - which, while
that's what a standards-compliant browser will interpret the lack of a SameSite attribute as, it's probably still better to only send it if we were told to, and omit it if not?